### PR TITLE
MOB-287 Update pending and open state icons

### DIFF
--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradestatus/components/DydxTradeStatusHeaderView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradestatus/components/DydxTradeStatusHeaderView.kt
@@ -90,17 +90,15 @@ object DydxTradeStatusHeaderView : DydxComponent {
                         )
                     }
                     StatusIcon.Pending -> {
-                        PlatformImage(
-                            modifier = Modifier
-                                .size(36.dp),
-                            icon = R.drawable.icon_search,
+                        PlatformIndeterminateProgress(
+                            size = 36.dp,
                         )
                     }
                     StatusIcon.Open -> {
                         PlatformImage(
                             modifier = Modifier
                                 .size(36.dp),
-                            icon = R.drawable.icon_search,
+                            icon = R.drawable.status_complete,
                         )
                     }
                     StatusIcon.Filled -> {

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradestatus/components/DydxTradeStatusPositionView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradestatus/components/DydxTradeStatusPositionView.kt
@@ -132,7 +132,7 @@ object DydxTradeStatusPositionView : DydxComponent {
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(81.dp)
-                    .background(ThemeColor.SemanticColor.layer_4.color, shape)
+                    .background(ThemeColor.SemanticColor.layer_3.color, shape)
                     .clip(shape),
                 verticalAlignment = Alignment.CenterVertically,
             ) {


### PR DESCRIPTION
Also update the background color of the position tab to make it more contrasty in light mode.

![Screenshot_20240301_103450_dYdX Debug](https://github.com/dydxprotocol/v4-native-android/assets/102453770/8dba108f-18a1-421f-be89-f436f34e549c)
![Screenshot_20240301_103452_dYdX Debug](https://github.com/dydxprotocol/v4-native-android/assets/102453770/26732dfa-3f0c-4643-a134-b6a1a85abbac)
![Screenshot_20240301_103543_dYdX Debug](https://github.com/dydxprotocol/v4-native-android/assets/102453770/940a2e84-da06-458b-8f6c-c25bdf85727c)
