### PR TITLE
Use limitedParallelism and MainScope() in AbacusThreadingImp.

### DIFF
--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusThreadingImp.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusThreadingImp.kt
@@ -2,16 +2,19 @@ package exchange.dydx.dydxstatemanager.protocolImplementations
 
 import exchange.dydx.abacus.protocols.ThreadingProtocol
 import exchange.dydx.abacus.protocols.ThreadingType
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.plus
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AbacusThreadingImp : ThreadingProtocol {
-    private val mainScope = CoroutineScope(Dispatchers.Main) // + Job())
-    private val abacusScope = CoroutineScope(newSingleThreadContext("AbacusScope"))
-    private val networkScope = CoroutineScope(Dispatchers.IO)
+    private val mainScope = MainScope()
+
+    // Abacus runs lots of computations, but needs to be run without parallelism
+    private val abacusScope = MainScope() + Dispatchers.Default.limitedParallelism(1)
+    private val networkScope = MainScope() + Dispatchers.IO
     override fun async(type: ThreadingType, block: () -> Unit) {
         when (type) {
             ThreadingType.main ->


### PR DESCRIPTION
Seeing a crash in `newSingleThreadContext("AbacusScope")` - we shouldn't be making an entire new thread for this anyways. We can use `limitedParallelism` instead. Also switched to use `MainScope` since that has a `SupervisorJob`. 