### PR TITLE
Handle exception with invalid URLs

### DIFF
--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusRestImp.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusRestImp.kt
@@ -67,7 +67,14 @@ class AbacusRestImp : RestProtocol {
         callback: (String?, Int) -> Unit,
     ) {
         var requestBuilder = Request.Builder()
-            .url(url)
+
+        try {
+            requestBuilder.url(url)
+        } catch (e: Exception) {
+            Log.e(TAG, "AbacusRestImp Invalid URL $url, ${e.message}")
+            callback(null, 0)
+            return
+        }
 
         val headers = headers?.toTypedArray()
         headers?.forEach { (key, value) ->

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusWebSocketImp.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusWebSocketImp.kt
@@ -1,5 +1,6 @@
 package exchange.dydx.dydxstatemanager.protocolImplementations
 
+import android.util.Log
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -9,6 +10,8 @@ import okio.ByteString
 import java.util.concurrent.TimeUnit
 
 class AbacusWebSocketImp : exchange.dydx.abacus.protocols.WebSocketProtocol {
+
+    private val TAG = "AbacusRestImp"
 
     private var url: String? = null
     private var connected: ((Boolean) -> Unit)? = null
@@ -40,38 +43,53 @@ class AbacusWebSocketImp : exchange.dydx.abacus.protocols.WebSocketProtocol {
 
     private fun connect() {
         url?.let { url ->
-            val request = Request.Builder().url(url).build()
-            val okHttpClient = OkHttpClient.Builder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(10, TimeUnit.SECONDS)
-                .writeTimeout(10, TimeUnit.SECONDS)
-                .build()
+            val request: Request?
 
-            val listener = object : WebSocketListener() {
-                override fun onOpen(webSocket: WebSocket, response: Response) {
-                    this@AbacusWebSocketImp.webSocket = webSocket
-                    connected?.invoke(true)
-                }
-
-                override fun onMessage(webSocket: WebSocket, text: String) {
-                    received?.invoke(text)
-                }
-
-                override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
-                    // Handle binary messages if needed
-                }
-
-                override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
-                    webSocket.close(NORMAL_CLOSURE, null)
-                    connected?.invoke(false)
-                }
-
-                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-                    connected?.invoke(false)
-                }
+            try {
+                request = Request.Builder().url(url).build()
+            } catch (e: Exception) {
+                connected?.invoke(false)
+                Log.e(TAG, "AbacusWebSocketImp Invalid URL $url, ${e.message}")
+                return
             }
 
-            okHttpClient.newWebSocket(request, listener)
+            if (request != null) {
+                val okHttpClient = OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(10, TimeUnit.SECONDS)
+                    .writeTimeout(10, TimeUnit.SECONDS)
+                    .build()
+
+                val listener = object : WebSocketListener() {
+                    override fun onOpen(webSocket: WebSocket, response: Response) {
+                        this@AbacusWebSocketImp.webSocket = webSocket
+                        connected?.invoke(true)
+                    }
+
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        received?.invoke(text)
+                    }
+
+                    override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                        // Handle binary messages if needed
+                    }
+
+                    override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                        webSocket.close(NORMAL_CLOSURE, null)
+                        connected?.invoke(false)
+                    }
+
+                    override fun onFailure(
+                        webSocket: WebSocket,
+                        t: Throwable,
+                        response: Response?
+                    ) {
+                        connected?.invoke(false)
+                    }
+                }
+
+                okHttpClient.newWebSocket(request, listener)
+            }
         }
     }
 }


### PR DESCRIPTION
Prevent app crash when deployment is misconfigured (e.g., when url in the env.json stays as the default "[HTTP link to ...]")