### PR TITLE
MOB-362: Some url links don't work with the deployment build

### DIFF
--- a/v4/common/src/main/java/exchange/dydx/trading/common/navigation/DydxRoutes.kt
+++ b/v4/common/src/main/java/exchange/dydx/trading/common/navigation/DydxRoutes.kt
@@ -54,16 +54,3 @@ object TransferRoutes {
     const val transfer_search = "transfer/search"
     const val transfer_status = "transfer/status"
 }
-
-// All routes paths that are used for deeplinking
-// This should match what's declared as intent-filters in the AndroidManifest
-val deeplinkRoutes: List<String> = listOf(
-    "markets",
-    "market",
-    "portfolio",
-    "settings",
-    "onboard",
-    "rewards",
-    "action",
-    "transfer",
-)

--- a/v4/core/src/main/java/exchange/dydx/trading/core/DydxRouterImpl.kt
+++ b/v4/core/src/main/java/exchange/dydx/trading/core/DydxRouterImpl.kt
@@ -14,7 +14,6 @@ import exchange.dydx.trading.common.AppConfig
 import exchange.dydx.trading.common.navigation.DydxRouter
 import exchange.dydx.trading.common.navigation.DydxRouter.Destination
 import exchange.dydx.trading.common.navigation.MarketRoutes
-import exchange.dydx.trading.common.navigation.deeplinkRoutes
 import exchange.dydx.trading.integration.analytics.Tracking
 import kotlinx.coroutines.flow.MutableStateFlow
 import timber.log.Timber
@@ -57,6 +56,19 @@ class DydxRouterImpl(
     private val dydxUris: List<String> = listOf(
         "https://${appConfig.appWebHost}",
         "${appConfig.appScheme}://${appConfig.appSchemeHost}",
+    )
+
+    // All routes paths that are used for deeplinking
+    // This should match what's declared as intent-filters in the AndroidManifest
+    private val deeplinkRoutes: List<String> = listOf(
+        "markets",
+        "market",
+        "portfolio",
+        "settings",
+        "onboard",
+        "rewards",
+        "action",
+        "transfer",
     )
 
     private val destinationChangedListener: (controller: NavController, destination: NavDestination, arguments: Bundle?) -> Unit =


### PR DESCRIPTION
The app should only do internal routing if the url path contains the deeplink it has declared.  For example, if the url is "https://{app_web_host]/markets", the app should navigate to "markets" only if "markets" is declared as a deeplink.  Otherwise, just open the url with the browser.

