### PR TITLE
Fix a crash on url tapping

### DIFF
--- a/v4/core/src/main/java/exchange/dydx/trading/core/DydxRouterImpl.kt
+++ b/v4/core/src/main/java/exchange/dydx/trading/core/DydxRouterImpl.kt
@@ -134,6 +134,7 @@ class DydxRouterImpl @Inject constructor(
         val routePath = routePath(route)
         if (routePath.startsWith("http://") || routePath.startsWith("https://")) {
             val intent = Intent(Intent.ACTION_VIEW, routePath.toUri())
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             application.startActivity(intent)
         } else {
             pendingPresentation =


### PR DESCRIPTION
Since the last dagger PR changed the applicationContext.startActivity() to application.startActivity(intent), the app crashes on 

```
Calling startActivity() from outside of an Activity  context requires the  
FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
```

Adding the flag to fix it.