### PR TITLE
Remove hardcoded scheme in the setting links.

### DIFF
--- a/v4/app/src/main/assets/settings.json
+++ b/v4/app/src/main/assets/settings.json
@@ -6,7 +6,7 @@
                     "text": "APP.LANGUAGE.LANGUAGE"
                 },
                 "link": {
-                    "text": "dydxv4://open/settings/language"
+                    "text": "settings/language"
                 },
                 "field": {
                     "field": "language"
@@ -17,7 +17,7 @@
                     "text" : "APP.V4.THEME"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/theme"
+                    "text" : "settings/theme"
                 },
                 "field":{
                     "field":"v4_theme"
@@ -28,7 +28,7 @@
                     "text" : "APP.V4.SYSTEM_STATUS"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/status"
+                    "text" : "settings/status"
                 }
             },
             {
@@ -36,7 +36,7 @@
                     "text" : "APP.V4.DIRECTION_COLOR_PREFERENCE"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/direction_color_preference"
+                    "text" : "settings/direction_color_preference"
                 },
                 "field":{
                     "field":"direction_color_preference"

--- a/v4/app/src/main/assets/settings_debug.json
+++ b/v4/app/src/main/assets/settings_debug.json
@@ -6,7 +6,7 @@
                     "text" : "APP.LANGUAGE.LANGUAGE"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/language"
+                    "text" : "settings/language"
                 },
                 "field":{
                     "field":"language"
@@ -17,7 +17,7 @@
                     "text" : "APP.V4.THEME"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/theme"
+                    "text" : "settings/theme"
                 },
                 "field":{
                     "field":"v4_theme"
@@ -28,7 +28,7 @@
                     "text" : "APP.V4.TRADING_NETWORK"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/env"
+                    "text" : "settings/env"
                 },
                 "field":{
                     "field":"env"
@@ -39,7 +39,7 @@
                     "text" : "APP.V4.SYSTEM_STATUS"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/status"
+                    "text" : "settings/status"
                 }
             },
             {
@@ -47,7 +47,7 @@
                     "text" : "Feature Flag Overrides"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/features"
+                    "text" : "features"
                 }
             },
             {
@@ -55,7 +55,7 @@
                     "text" : "Debug Settings"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/debug"
+                    "text" : "settings/debug"
                 }
             },
             {
@@ -63,7 +63,7 @@
                     "text" : "APP.V4.DIRECTION_COLOR_PREFERENCE"
                 },
                 "link" : {
-                    "text" : "dydxv4://open/settings/direction_color_preference"
+                    "text" : "settings/direction_color_preference"
                 },
                 "field":{
                     "field":"direction_color_preference"


### PR DESCRIPTION
Hardcoded scheme doesn't work now that we will use a different scheme than "dydxv4" for internal build.   We don't need the scheme in the settings.json anyway since the links are internal anyway.