### PR TITLE
MOB-285: Call startTrade() after setMarket()

### DIFF
--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/streams/MarketInfoStream.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/streams/MarketInfoStream.kt
@@ -46,6 +46,7 @@ class MarketInfoStream @Inject constructor(
 
     override fun update(marketId: String?) {
         abacusStateManager.setMarket(marketId)
+        abacusStateManager.startTrade()
     }
 
     override val market: Flow<PerpetualMarket?> =

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/DydxTradeInputViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/DydxTradeInputViewModel.kt
@@ -24,7 +24,6 @@ class DydxTradeInputViewModel @Inject constructor(
 ) : ViewModel(), DydxViewModel {
 
     init {
-        abacusStateManager.startTrade()
         receiptTypeFlow.value = ReceiptType.Trade(TradeReceiptType.Open)
     }
 


### PR DESCRIPTION
Fix the issue of blank trade page when going to Eth market from Positions tab on Launch.  This doesn't happen consistently (on some devices it never happens), since it's caused by a race condition of the MarketInfoView and TradeInputView.   This PR remove the race condition by always calling startTrade() after setMarket().

