### PR TITLE
Convert AbacusState flows into StateFlows.

### DIFF
--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusState.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusState.kt
@@ -3,6 +3,7 @@ package exchange.dydx.dydxstatemanager
 import com.hoc081098.flowext.throttleTime
 import exchange.dydx.abacus.output.Account
 import exchange.dydx.abacus.output.Asset
+import exchange.dydx.abacus.output.Configs
 import exchange.dydx.abacus.output.Documentation
 import exchange.dydx.abacus.output.LaunchIncentive
 import exchange.dydx.abacus.output.LaunchIncentivePoints
@@ -39,186 +40,126 @@ import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferInstance
 import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferState
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletInstance
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletState
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.newSingleThreadContext
-import javax.inject.Inject
+import kotlinx.coroutines.flow.stateIn
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AbacusState @Inject constructor(
-    private val walletStatePublisher: Flow<DydxWalletState?>,
-    private val perpetualStatePublisher: Flow<PerpetualState?>,
-    private val apiStatePublisher: Flow<ApiState?>,
-    private val errorsStatePublisher: Flow<List<ParsingError>?>,
-    private val lastOrderPublisher: Flow<SubaccountOrder?>,
-    private val alertsPublisher: Flow<List<Notification>?>,
-    private val documentationPublisher: Flow<Documentation?>,
-    private val transferStatePublisher: Flow<DydxTransferState?>,
+class AbacusState(
+    val walletState: StateFlow<DydxWalletState?>,
+    private val perpetualState: StateFlow<PerpetualState?>,
+    private val apiPerpetualState: StateFlow<ApiState?>,
+    private val errorsPerpetualState: StateFlow<List<ParsingError>?>,
+    private val lastOrderPublisher: StateFlow<SubaccountOrder?>,
+    val alerts: StateFlow<List<Notification>?>,
+    val documentation: StateFlow<Documentation?>,
+    val transferState: StateFlow<DydxTransferState?>,
     private val abacusStateManager: AsyncAbacusStateManager,
-    private var parser: ParserProtocol,
+    private val parser: ParserProtocol,
 ) {
+
+    private val stateManagerScope = MainScope()
+
     var isMainNet: Boolean? = null
         get() = abacusStateManager.environment?.isMainNet ?: false
 
     /**
      Onboarded
      **/
-    val onboarded: Flow<Boolean> by lazy {
-        walletStatePublisher
+    val onboarded: StateFlow<Boolean> by lazy {
+        walletState
             .map { walletState ->
                 walletState?.currentWallet?.let { currentWallet ->
                     currentWallet.cosmoAddress?.isNotEmpty() == true
                 } ?: false
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
-    }
-
-    /**
-     WalletState
-     **/
-    val walletState: Flow<DydxWalletState?> by lazy {
-        walletStatePublisher
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, false)
     }
 
     /**
      Current wallet
      **/
-    val currentWallet: Flow<DydxWalletInstance?> by lazy {
+    val currentWallet: StateFlow<DydxWalletInstance?> by lazy {
         walletState
             .map { it?.currentWallet }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    /**
-     Frontend alerts
-     **/
-    val alerts: Flow<List<Notification>?> by lazy {
-        alertsPublisher
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
-    }
-
-    /**
-     Documentation
-     **/
-    val documentation: Flow<Documentation?> by lazy {
-        documentationPublisher
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
-    }
-
-    /**
-     TransferState (client state of the pending transfers)
-     **/
-    val transferState: Flow<DydxTransferState?> by lazy {
-        transferStatePublisher
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
-    }
-
-    val transfers: Flow<List<SubaccountTransfer>?> by lazy {
-        statePublisher
+    val transfers: StateFlow<List<SubaccountTransfer>?> by lazy {
+        perpetualState
             .map { it?.transfers }
             .map {
                 val subaccountNumber = subaccountNumber ?: return@map null
                 it?.get(subaccountNumber)?.toList() ?: null
             }
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    fun transferInstance(transactionHash: String?): Flow<DydxTransferInstance?> {
+    fun transferInstance(transactionHash: String?): StateFlow<DydxTransferInstance?> {
         return transferState
             .map { it?.transfers?.first { it.transactionHash == transactionHash } }
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      TransferStatuses (Abacus state of transfer statuses)
      **/
-    val transferStatuses: Flow<Map<String, TransferStatus>?> by lazy {
-        perpetualStatePublisher
-            .map { it?.transferStatuses }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+    val transferStatuses: StateFlow<Map<String, TransferStatus>> by lazy {
+        perpetualState
+            .map { it?.transferStatuses ?: emptyMap() }
+            .stateIn(stateManagerScope, SharingStarted.Lazily, emptyMap())
     }
 
     /**
      Account
      **/
-    val account: Flow<Account?> by lazy {
-        perpetualStatePublisher
+    val account: StateFlow<Account?> by lazy {
+        perpetualState
             .map { it?.account }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    val hasAccount: Flow<Boolean> by lazy {
+    val hasAccount: StateFlow<Boolean> by lazy {
         account
             .map { it != null }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, false)
     }
 
     /**
      Account balances (wallet balances)
      **/
 
-    fun accountBalance(tokenDenom: String?): Flow<Double?> {
-        return statePublisher
+    fun accountBalance(tokenDenom: String?): StateFlow<Double?> {
+        return perpetualState
             .map { state: PerpetualState? ->
                 state?.account?.balances?.get(tokenDenom)?.amount?.toDoubleOrNull()
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    fun stakingBalance(tokenDenom: String?): Flow<Double?> {
-        return statePublisher
+    fun stakingBalance(tokenDenom: String?): StateFlow<Double?> {
+        return perpetualState
             .map { state: PerpetualState? ->
                 state?.account?.stakingBalances?.get(tokenDenom)?.amount?.toDoubleOrNull()
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Subaccount
      **/
-    fun subaccount(subaccountNumber: String): Flow<Subaccount?> {
+    fun subaccount(subaccountNumber: String): StateFlow<Subaccount?> {
         return account
             .map { it?.subaccounts?.get(subaccountNumber) }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    val selectedSubaccount: Flow<Subaccount?> by lazy {
-        statePublisher
+    val selectedSubaccount: StateFlow<Subaccount?> by lazy {
+        perpetualState
             .map {
                 if (subaccountNumber != null) {
                     it?.account?.subaccounts?.get(subaccountNumber)
@@ -226,13 +167,11 @@ class AbacusState @Inject constructor(
                     null
                 }
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    val selectedSubaccountFills: Flow<List<SubaccountFill>?> by lazy {
-        statePublisher
+    val selectedSubaccountFills: StateFlow<List<SubaccountFill>?> by lazy {
+        perpetualState
             .map {
                 if (subaccountNumber != null) {
                     it?.fills?.get(subaccountNumber)?.toList()
@@ -240,13 +179,11 @@ class AbacusState @Inject constructor(
                     null
                 }
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    val selectedSubaccountFundings: Flow<List<SubaccountFundingPayment>?> by lazy {
-        statePublisher
+    val selectedSubaccountFundings: StateFlow<List<SubaccountFundingPayment>?> by lazy {
+        perpetualState
             .map {
                 if (subaccountNumber != null) {
                     it?.fundingPayments?.get(subaccountNumber)?.toList()
@@ -254,33 +191,27 @@ class AbacusState @Inject constructor(
                     null
                 }
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    val selectedSubaccountPositions: Flow<List<SubaccountPosition>?> by lazy {
+    val selectedSubaccountPositions: StateFlow<List<SubaccountPosition>?> by lazy {
         selectedSubaccount
             .map { subaccount ->
                 subaccount?.openPositions
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    val selectedSubaccountOrders: Flow<List<SubaccountOrder>?> by lazy {
+    val selectedSubaccountOrders: StateFlow<List<SubaccountOrder>?> by lazy {
         selectedSubaccount
             .map { subaccount ->
                 subaccount?.orders
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    val selectedSubaccountPNLs: Flow<List<SubaccountHistoricalPNL>?> by lazy {
-        statePublisher
+    val selectedSubaccountPNLs: StateFlow<List<SubaccountHistoricalPNL>?> by lazy {
+        perpetualState
             .map {
                 if (subaccountNumber != null) {
                     it?.historicalPnl?.get(subaccountNumber)?.toList()
@@ -288,142 +219,118 @@ class AbacusState @Inject constructor(
                     null
                 }
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Fundings
      **/
-    val historicalFundingsMap: Flow<Map<String, List<MarketHistoricalFunding>>?> by lazy {
-        statePublisher
+    val historicalFundingsMap: StateFlow<Map<String, List<MarketHistoricalFunding>>?> by lazy {
+        perpetualState
             .map { it?.historicalFundings }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Fundings of a given market
      **/
-    fun historicalFundings(marketId: String): Flow<List<MarketHistoricalFunding>?> {
+    fun historicalFundings(marketId: String): StateFlow<List<MarketHistoricalFunding>?> {
         return historicalFundingsMap
             .map { it?.get(marketId) }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Market Summary
      **/
-    val marketSummary: Flow<PerpetualMarketSummary?> by lazy {
-        statePublisher
+    val marketSummary: StateFlow<PerpetualMarketSummary?> by lazy {
+        perpetualState
             .map {
                 it?.marketsSummary
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Map from market ID to Candles
      **/
-    val candlesMap: Flow<Map<String, MarketCandles>?> by lazy {
-        statePublisher
+    val candlesMap: StateFlow<Map<String, MarketCandles>?> by lazy {
+        perpetualState
             .map { it?.candles }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Candles of a given market
      **/
-    fun candles(marketId: String): Flow<MarketCandles?> {
+    fun candles(marketId: String): StateFlow<MarketCandles?> {
         return candlesMap
             .map { it?.get(marketId) }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Map from market ID to Orderbook
      **/
-    val orderbooksMap: Flow<Map<String, MarketOrderbook>?> by lazy {
-        statePublisher
+    val orderbooksMap: StateFlow<Map<String, MarketOrderbook>?> by lazy {
+        perpetualState
             .map {
                 it?.orderbooks
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Orderbook of a given market
      **/
-    fun orderbook(marketId: String): Flow<MarketOrderbook?> {
+    fun orderbook(marketId: String): StateFlow<MarketOrderbook?> {
         return orderbooksMap
             .map { it?.get(marketId) }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Map from market ID to Trades
      **/
-    val tradesMap: Flow<Map<String, List<MarketTrade>>?> by lazy {
-        statePublisher
+    val tradesMap: StateFlow<Map<String, List<MarketTrade>>?> by lazy {
+        perpetualState
             .map { it?.trades }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Trades of a given market
      **/
-    fun trade(marketId: String): Flow<List<MarketTrade>?> {
+    fun trade(marketId: String): StateFlow<List<MarketTrade>?> {
         return tradesMap
             .map { it?.get(marketId) }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      List of market IDs
      **/
-    val markeeIds: Flow<List<String>?> by lazy {
+    val markeeIds: StateFlow<List<String>?> by lazy {
         marketSummary
             .map { it?.marketIds() }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Map from market ID to Market
      **/
-    val marketMap: Flow<Map<String, PerpetualMarket>?> by lazy {
+    val marketMap: StateFlow<Map<String, PerpetualMarket>?> by lazy {
         marketSummary
             .map {
                 it?.markets
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      List Market ordrered by market IDs
      **/
-    val marketList: Flow<List<PerpetualMarket>?> by lazy {
+    val marketList: StateFlow<List<PerpetualMarket>?> by lazy {
         combine(
             markeeIds,
             marketMap,
@@ -432,43 +339,36 @@ class AbacusState @Inject constructor(
                 map?.get(id)
             }
         }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Market of a given market ID
      **/
-    fun market(marketId: String): Flow<PerpetualMarket?> {
+    fun market(marketId: String): StateFlow<PerpetualMarket?> {
         return marketMap
             .map {
                 it?.get(marketId)
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Asset of given asset Id
      **/
-    val assetMap: Flow<Map<String, Asset>?> by lazy {
-        statePublisher
+    val assetMap: StateFlow<Map<String, Asset>?> by lazy {
+        perpetualState
             .map { it?.assets }
-            .distinctUntilChanged()
-            //   .throttleTime(1000)
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      MarketConfigs and Asset map
      **/
-    val configsAndAssetMap: Flow<Map<String, MarketConfigsAndAsset>?> by lazy {
+    val configsAndAssetMap: StateFlow<Map<String, MarketConfigsAndAsset>?> by lazy {
         combine(
             marketMap,
-            statePublisher.map { it?.assets },
+            perpetualState.map { it?.assets },
         ) { marketMap: Map<String, PerpetualMarket>?, assetMap: Map<String, Asset>? ->
             val output = mutableMapOf<String, MarketConfigsAndAsset>()
             marketMap?.forEach { (marketId, market) ->
@@ -477,86 +377,72 @@ class AbacusState @Inject constructor(
             }
             output
         }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Trade input
      **/
-    val tradeInput: Flow<TradeInput?> by lazy {
-        statePublisher
+    val tradeInput: StateFlow<TradeInput?> by lazy {
+        perpetualState
             .map { it?.input?.trade }
-            .distinctUntilChanged()
             .throttleTime(10)
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Close Position input
      **/
-    val closePositionInput: Flow<ClosePositionInput?> by lazy {
-        statePublisher
+    val closePositionInput: StateFlow<ClosePositionInput?> by lazy {
+        perpetualState
             .map { it?.input?.closePosition }
-            .distinctUntilChanged()
             .throttleTime(10)
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Transfer input
      **/
-    val transferInput: Flow<TransferInput?> by lazy {
-        statePublisher
+    val transferInput: StateFlow<TransferInput?> by lazy {
+        perpetualState
             .map { it?.input?.transfer }
-            .distinctUntilChanged()
             .throttleTime(10)
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Input receipts
      **/
-    val receipts: Flow<List<ReceiptLine>> by lazy {
-        statePublisher
+    val receipts: StateFlow<List<ReceiptLine>> by lazy {
+        perpetualState
             .map { it?.input?.receiptLines ?: emptyList() }
-            .distinctUntilChanged()
             .throttleTime(10)
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, emptyList())
     }
 
     /**
      Input validation
      **/
-    val validationErrors: Flow<List<ValidationError>> by lazy {
-        statePublisher
+    val validationErrors: StateFlow<List<ValidationError>> by lazy {
+        perpetualState
             .map { it?.input?.errors ?: emptyList() }
-            .distinctUntilChanged()
             .throttleTime(10)
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, emptyList())
     }
 
     /**
      Last Order
      */
-    val lastOrder: Flow<SubaccountOrder?> by lazy {
+    val lastOrder: StateFlow<SubaccountOrder?> by lazy {
         lastOrderPublisher
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Backend Error
      */
-    val backendError: Flow<ParsingError?> by lazy {
-        errorsStatePublisher
+    val backendError: StateFlow<ParsingError?> by lazy {
+        errorsPerpetualState
             .map { errors ->
                 errors?.firstOrNull { error ->
                     when (error.type) {
@@ -565,85 +451,59 @@ class AbacusState @Inject constructor(
                     }
                 }
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Config
      */
-    val configs: Flow<exchange.dydx.abacus.output.Configs?> by lazy {
-        statePublisher
+    val configs: StateFlow<Configs?> by lazy {
+        perpetualState
             .map { it?.configs }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      User
      **/
-    val user: Flow<User?> by lazy {
-        statePublisher
+    val user: StateFlow<User?> by lazy {
+        perpetualState
             .map { it?.wallet?.user }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      Launch Incentives
      **/
-    val launchIncentive: Flow<LaunchIncentive?> by lazy {
-        statePublisher
+    val launchIncentive: StateFlow<LaunchIncentive?> by lazy {
+        perpetualState
             .map {
                 it?.launchIncentive
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
-    val launchIncentivePoints: Flow<LaunchIncentivePoints?> by lazy {
-        statePublisher
+    val launchIncentivePoints: StateFlow<LaunchIncentivePoints?> by lazy {
+        perpetualState
             .map {
                 it?.account?.launchIncentivePoints
             }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 
     /**
      ApiState
      */
-    val apiState: Flow<ApiState?> by lazy {
-        apiStatePublisher
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
-    }
+    val apiState: StateFlow<ApiState?> = apiPerpetualState
 
     /**
      Restriction
      */
-    val restriction: Flow<Restriction> by lazy {
-        statePublisher
+    val restriction: StateFlow<Restriction> by lazy {
+        perpetualState
             .map { it?.restriction?.restriction ?: Restriction.NO_RESTRICTION }
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
+            .stateIn(stateManagerScope, SharingStarted.Lazily, Restriction.NO_RESTRICTION)
     }
-
-    private val statePublisher: Flow<PerpetualState?> by lazy {
-        perpetualStatePublisher
-            .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
-            .shareIn(stateManagerScope, SharingStarted.Lazily, 1)
-    }
-
-    private val stateManagerScope = CoroutineScope(newSingleThreadContext("AbacusStateManager"))
 
     private val subaccountNumber: String?
         get() = parser.asString(abacusStateManager.subaccountNumber)

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
@@ -117,13 +117,13 @@ interface AbacusStateManagerProtocol {
 class AbacusStateManager @Inject constructor(
     private val application: Application,
     private val ioImplementations: IOImplementations,
-    private val parser: ParserProtocol,
     private val walletStateManager: DydxWalletStateManagerProtocol,
     private val transferStateManager: DydxTransferStateManagerProtocol,
     private val cosmosClient: CosmosV4ClientProtocol,
     private val preferencesStore: SharedPreferencesStore,
     @EnvKey private val envKey: String,
     private val featureFlags: DydxFeatureFlags,
+    parser: ParserProtocol,
 ) : AbacusStateManagerProtocol, StateNotificationProtocol {
 
     private val perpetualStatePublisher: MutableStateFlow<PerpetualState?> = MutableStateFlow(null)
@@ -160,16 +160,16 @@ class AbacusStateManager @Inject constructor(
 
     // MARK: AbacusStateManagerProtocol
 
-    override var state: AbacusState = AbacusState(
-        walletStatePublisher = walletStateManager.state,
-        perpetualStatePublisher = perpetualStatePublisher,
-        apiStatePublisher = apiStatePublisher,
-        errorsStatePublisher = errorsStatePublisher,
+    override val state: AbacusState = AbacusState(
+        walletState = walletStateManager.state,
+        perpetualState = perpetualStatePublisher,
+        apiPerpetualState = apiStatePublisher,
+        errorsPerpetualState = errorsStatePublisher,
         lastOrderPublisher = lastOrderPublisher,
-        alertsPublisher = alertsPublisher,
-        documentationPublisher = documentationPublisher,
+        alerts = alertsPublisher,
+        documentation = documentationPublisher,
         abacusStateManager = asyncStateManager,
-        transferStatePublisher = transferStateManager.state,
+        transferState = transferStateManager.state,
         parser = parser,
     )
 

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/clientState/transfers/DydxTransferState.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/clientState/transfers/DydxTransferState.kt
@@ -3,15 +3,15 @@ package exchange.dydx.dydxstatemanager.clientState.transfers
 import android.os.Build
 import androidx.annotation.RequiresApi
 import exchange.dydx.dydxstatemanager.clientState.DydxClientState
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
 interface DydxTransferStateManagerProtocol {
-    val state: Flow<DydxTransferState?>
+    val state: StateFlow<DydxTransferState?>
     fun add(transfer: DydxTransferInstance)
     fun remove(transfer: DydxTransferInstance)
     fun clear()
@@ -33,7 +33,7 @@ class DydxTransferStateManager @Inject constructor(
         mutableState.value = state
     }
 
-    override val state: Flow<DydxTransferState?> by lazy { mutableState }
+    override val state: StateFlow<DydxTransferState?> = mutableState
 
     override fun add(transfer: DydxTransferInstance) {
         val current = mutableState.value ?: DydxTransferState()


### PR DESCRIPTION
This is a first pass that simply converts our Flows into StateFlows. I'll do another pass on usages to convert any `.first()` calls to accessing the value directly.