### PR TITLE
Fix issue of text input losing calculated value when not focused

### DIFF
--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/size/DydxTradeInputSizeView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/size/DydxTradeInputSizeView.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -80,6 +81,7 @@ object DydxTradeInputSizeView : DydxComponent {
         }
 
         val showingUsdc = remember { mutableStateOf(state.showingUsdc) }
+        val focusManager = LocalFocusManager.current
 
         InputFieldScarfold(modifier) {
             Column {
@@ -111,7 +113,10 @@ object DydxTradeInputSizeView : DydxComponent {
 
                     PlatformAccessoryButton(
                         modifier = Modifier,
-                        action = { showingUsdc.value = !showingUsdc.value },
+                        action = {
+                            focusManager.clearFocus()
+                            showingUsdc.value = !showingUsdc.value
+                        },
                     ) {
                         Column(
                             modifier = Modifier.padding(ThemeShapes.InputPaddingValues),

--- a/v4/platformUI/src/main/java/exchange/dydx/platformui/components/inputs/PlatformTextInput.kt
+++ b/v4/platformUI/src/main/java/exchange/dydx/platformui/components/inputs/PlatformTextInput.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
-import androidx.compose.material.TextFieldColors
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -60,7 +59,10 @@ fun PlatformTextInput(
             }
             val interactionSource = remember { MutableInteractionSource() }
             val isFocused by interactionSource.collectIsFocusedAsState()
-            val currentValue = remember { mutableStateOf<String?>(null) }
+            val currentValue = remember { mutableStateOf<String?>(value) } // value during editing
+            if (!isFocused) {
+                currentValue.value = value
+            }
             val displayValue = if (isFocused) currentValue.value ?: "" else value ?: ""
 
             BasicTextField(
@@ -98,69 +100,6 @@ fun PlatformTextInput(
                     )
                 },
             )
-
-//        TextField(
-//            modifier = Modifier,
-//            value = displayValue,
-//            onValueChange = {
-//                currentValue.value = it
-//                onValueChange(it)
-//            },
-//            //  label = label,
-//            placeholder = {
-//                Text(
-//                    text = placeHolder ?: "",
-//                    style = TextStyle.dydxDefault
-//                        .themeFont(fontSize = ThemeFont.FontSize.medium)
-//                        .themeColor(ThemeColor.SemanticColor.text_tertiary)
-//                )
-//            },
-//            interactionSource = interactionSource,
-//            singleLine = true,
-//            colors = inputFieldColors,
-//            textStyle = TextStyle.dydxDefault
-//                .themeFont(fontSize = ThemeFont.FontSize.medium)
-//        )
         }
     }
 }
-
-@Composable
-fun PlatformTextInput(
-    labelText: String? = null,
-    value: String? = null,
-    placeHolder: String? = null,
-    onValueChange: (String) -> Unit = {},
-) {
-    PlatformTextInput(
-        label = if (labelText?.isNotEmpty() == true) { {
-            Text(
-                text = labelText ?: "",
-                style = TextStyle.dydxDefault
-                    .themeFont(fontSize = ThemeFont.FontSize.mini)
-                    .themeColor(ThemeColor.SemanticColor.text_tertiary),
-            )
-        } } else {
-            null
-        },
-        value = value,
-        placeHolder = placeHolder,
-        onValueChange = onValueChange,
-    )
-}
-
-private val inputFieldColors: TextFieldColors
-    @Composable
-    get() = TextFieldDefaults.textFieldColors(
-        textColor = ThemeColor.SemanticColor.text_primary.color,
-        disabledTextColor = ThemeColor.SemanticColor.text_tertiary.color,
-        backgroundColor = ThemeColor.SemanticColor.transparent.color,
-        focusedIndicatorColor = ThemeColor.SemanticColor.transparent.color,
-        unfocusedIndicatorColor = ThemeColor.SemanticColor.transparent.color,
-        errorIndicatorColor = ThemeColor.SemanticColor.transparent.color,
-        cursorColor = ThemeColor.SemanticColor.text_primary.color,
-        errorCursorColor = ThemeColor.SemanticColor.color_yellow.color,
-        errorLabelColor = ThemeColor.SemanticColor.color_yellow.color,
-        errorLeadingIconColor = ThemeColor.SemanticColor.color_yellow.color,
-        errorTrailingIconColor = ThemeColor.SemanticColor.color_yellow.color,
-    )


### PR DESCRIPTION
Value of an input field can be updated by another input or data change, so it needs to be updated when the field is not on focus.

Before:
[before.webm](https://github.com/dydxprotocol/v4-native-android/assets/102453770/ba2f784d-a8eb-492d-920a-f44a70da400d)


After:
[after.webm](https://github.com/dydxprotocol/v4-native-android/assets/102453770/2d728864-7498-46e2-800c-4b69f3234d06)
