### PR TITLE
Inject coroutine scopes and dispatchers instead of hardcoding.

### DIFF
--- a/v4/app/src/main/java/exchange/dydx/trading/AppModule.kt
+++ b/v4/app/src/main/java/exchange/dydx/trading/AppModule.kt
@@ -46,6 +46,7 @@ import exchange.dydx.platformui.designSystem.theme.ThemeConfig
 import exchange.dydx.platformui.designSystem.theme.ThemeSettings
 import exchange.dydx.trading.common.AppConfig
 import exchange.dydx.trading.common.AppConfigImpl
+import exchange.dydx.trading.common.di.CoroutineScopes
 import exchange.dydx.trading.common.theme.DydxTheme
 import exchange.dydx.trading.common.theme.DydxThemeImpl
 import exchange.dydx.trading.feature.shared.PreferenceKeys
@@ -57,6 +58,7 @@ import exchange.dydx.trading.integration.cosmos.CosmosV4ClientWebview
 import exchange.dydx.trading.integration.cosmos.CosmosV4WebviewClientProtocol
 import exchange.dydx.utilities.utils.JsonUtils
 import exchange.dydx.utilities.utils.SharedPreferencesStore
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.json.Json
 import javax.inject.Singleton
@@ -109,10 +111,13 @@ interface AppModule {
         fun provideLanguageKey(): String = PreferenceKeys.Language
 
         @Provides
-        fun providePlatformInfo(): PlatformInfo =
+        fun providePlatformInfo(
+            @CoroutineScopes.App appScope: CoroutineScope,
+        ): PlatformInfo =
             PlatformInfo(
                 snackbarHostState = SnackbarHostState(),
                 infoType = MutableStateFlow(PlatformInfo.InfoType.Info),
+                appScope = appScope,
             )
 
         @Provides

--- a/v4/common/src/main/java/exchange/dydx/trading/common/di/CoroutineDispatchers.kt
+++ b/v4/common/src/main/java/exchange/dydx/trading/common/di/CoroutineDispatchers.kt
@@ -1,0 +1,31 @@
+package exchange.dydx.trading.common.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+
+object CoroutineDispatchers {
+
+    @Qualifier annotation class Main
+
+    @Qualifier annotation class IO
+
+    @Qualifier annotation class Default
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoroutineDispatchersModule {
+    @Provides @CoroutineDispatchers.Main
+    fun provideMain(): CoroutineDispatcher = Dispatchers.Main
+
+    @Provides @CoroutineDispatchers.IO
+    fun provideIO(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides @CoroutineDispatchers.Default
+    fun provideDefault(): CoroutineDispatcher = Dispatchers.Default
+}

--- a/v4/common/src/main/java/exchange/dydx/trading/common/di/CoroutineScopes.kt
+++ b/v4/common/src/main/java/exchange/dydx/trading/common/di/CoroutineScopes.kt
@@ -1,0 +1,40 @@
+package exchange.dydx.trading.common.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.ViewModelLifecycle
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+object CoroutineScopes {
+    @Qualifier annotation class App
+
+    @Qualifier annotation class ViewModel
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppScopeModule {
+    @Provides @CoroutineScopes.App @Singleton
+    fun provideScope(): CoroutineScope = MainScope()
+}
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object ViewModelScopeModule {
+    @Provides @CoroutineScopes.ViewModel @ViewModelScoped
+    fun provideScope(viewModelLifecycle: ViewModelLifecycle): CoroutineScope {
+        val scope = MainScope()
+        viewModelLifecycle.addOnClearedListener {
+            scope.cancel()
+        }
+        return scope
+    }
+}

--- a/v4/feature/profile/src/main/java/exchange/dydx/trading/feature/profile/reportissue/DydxReportIssueViewModel.kt
+++ b/v4/feature/profile/src/main/java/exchange/dydx/trading/feature/profile/reportissue/DydxReportIssueViewModel.kt
@@ -11,11 +11,12 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.platformui.components.PlatformInfo
 import exchange.dydx.trading.common.DydxViewModel
+import exchange.dydx.trading.common.di.CoroutineDispatchers
 import exchange.dydx.trading.common.navigation.DydxRouter
 import exchange.dydx.utilities.utils.EmailUtils
 import exchange.dydx.utilities.utils.FileUtils
 import exchange.dydx.utilities.utils.LogCatReader
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -30,6 +31,7 @@ class DydxReportIssueViewModel @Inject constructor(
     private val localizer: LocalizerProtocol,
     private val router: DydxRouter,
     @ApplicationContext private val context: Context,
+    @CoroutineDispatchers.IO private val ioDispatcher: CoroutineDispatcher,
     val platformInfo: PlatformInfo,
 ) : ViewModel(), DydxViewModel {
 
@@ -44,7 +46,7 @@ class DydxReportIssueViewModel @Inject constructor(
 
         viewModelScope.launch {
             var logUri: Uri? = null
-            withContext(Dispatchers.IO) {
+            withContext(ioDispatcher) {
                 // add a delay to show the loading text
                 kotlinx.coroutines.delay(500)
                 logUri = createLog()

--- a/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/analytics/OnboardingAnalytics.kt
+++ b/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/analytics/OnboardingAnalytics.kt
@@ -1,9 +1,11 @@
 package exchange.dydx.trading.feature.shared.analytics
 
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
+import exchange.dydx.trading.common.di.CoroutineDispatchers
+import exchange.dydx.trading.common.di.CoroutineScopes
 import exchange.dydx.trading.integration.analytics.Tracking
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
@@ -15,6 +17,8 @@ import javax.inject.Singleton
 class OnboardingAnalytics @Inject constructor(
     private val tracker: Tracking,
     private val abacusStateManager: AbacusStateManagerProtocol,
+    @CoroutineScopes.App private val appScope: CoroutineScope,
+    @CoroutineDispatchers.IO private val ioDispatcher: CoroutineDispatcher,
 ) {
     // The three main OnboardingStates:
     // - Disconnected
@@ -46,7 +50,7 @@ class OnboardingAnalytics @Inject constructor(
         DEPOSIT_FUNDS("DepositFunds")
     }
 
-    private val scope = MainScope() + Dispatchers.IO
+    private val scope = appScope + ioDispatcher
 
     fun log(step: OnboardingSteps) {
         abacusStateManager.state.currentWallet

--- a/v4/integration/cosmos/src/main/java/exchange/dydx/trading/integration/cosmos/CosmosV4ClientWebview.kt
+++ b/v4/integration/cosmos/src/main/java/exchange/dydx/trading/integration/cosmos/CosmosV4ClientWebview.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import android.util.Log
 import exchange.dydx.integration.javascript.JavascriptApiImpl
 import exchange.dydx.integration.javascript.JavascriptRunnerV4
+import exchange.dydx.trading.common.di.CoroutineScopes
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
 import java.util.Locale
@@ -17,11 +19,12 @@ private const val TAG = "CosmosV4ClientWebview"
 @Singleton
 class CosmosV4ClientWebview @Inject constructor(
     application: Application,
+    @CoroutineScopes.App appScope: CoroutineScope,
 ) : CosmosV4WebviewClientProtocol,
     JavascriptApiImpl(
         context = application,
         description = WEBVIEW_FILENAME,
-        runner = JavascriptRunnerV4.runnerFromFile(application, WEBVIEW_FILENAME)
+        runner = JavascriptRunnerV4.runnerFromFile(appScope, application, WEBVIEW_FILENAME)
             ?: throw IOException("Fatal, unable to load runner from: $WEBVIEW_FILENAME"),
     ) {
 

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
@@ -44,12 +44,12 @@ import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletInstance
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletStateManagerProtocol
 import exchange.dydx.dydxstatemanager.protocolImplementations.UIImplementationsExtensions
 import exchange.dydx.trading.common.R
+import exchange.dydx.trading.common.di.CoroutineScopes
 import exchange.dydx.trading.common.featureflags.DydxFeatureFlag
 import exchange.dydx.trading.common.featureflags.DydxFeatureFlags
 import exchange.dydx.trading.integration.cosmos.CosmosV4ClientProtocol
 import exchange.dydx.utilities.utils.SharedPreferencesStore
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -130,6 +130,7 @@ class AbacusStateManager @Inject constructor(
     private val preferencesStore: SharedPreferencesStore,
     @EnvKey private val envKey: String,
     private val featureFlags: DydxFeatureFlags,
+    @CoroutineScopes.App private val appScope: CoroutineScope,
     parser: ParserProtocol,
 ) : AbacusStateManagerProtocol, StateNotificationProtocol {
 
@@ -429,7 +430,7 @@ class AbacusStateManager @Inject constructor(
     }
 
     private fun start() {
-        CoroutineScope(Dispatchers.Main).launch {
+        appScope.launch {
             val currentWallet = walletStateManager.state.first()?.currentWallet
             if (currentWallet != null) {
                 val ethereumAddress = currentWallet.ethereumAddress

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusThreadingImp.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusThreadingImp.kt
@@ -2,41 +2,35 @@ package exchange.dydx.dydxstatemanager.protocolImplementations
 
 import exchange.dydx.abacus.protocols.ThreadingProtocol
 import exchange.dydx.abacus.protocols.ThreadingType
-import kotlinx.coroutines.Dispatchers
+import exchange.dydx.abacus.protocols.ThreadingType.abacus
+import exchange.dydx.abacus.protocols.ThreadingType.main
+import exchange.dydx.abacus.protocols.ThreadingType.network
+import exchange.dydx.trading.common.di.CoroutineDispatchers
+import exchange.dydx.trading.common.di.CoroutineScopes
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
-class AbacusThreadingImp @Inject constructor() : ThreadingProtocol {
-    private val mainScope = MainScope()
-
-    // Abacus runs lots of computations, but needs to be run without parallelism
-    private val abacusScope = MainScope() + Dispatchers.Default.limitedParallelism(1)
-    private val networkScope = MainScope() + Dispatchers.IO
+class AbacusThreadingImp @Inject constructor(
+    @CoroutineScopes.App private val appScope: CoroutineScope,
+    @CoroutineDispatchers.IO private val ioDispatcher: CoroutineDispatcher,
+    @CoroutineDispatchers.Default private val defaultDispatcher: CoroutineDispatcher,
+) : ThreadingProtocol {
     override fun async(type: ThreadingType, block: () -> Unit) {
-        when (type) {
-            ThreadingType.main ->
-                mainScope
-                    .launch {
-                        block()
-                    }
-
-            ThreadingType.abacus ->
-                abacusScope
-                    .launch {
-                        block()
-                    }
-
-            ThreadingType.network ->
-                networkScope
-                    .launch {
-                        block()
-                    }
+        appScope.launch {
+            when (type) {
+                main -> block()
+                // Abacus runs lots of computations, but needs to be run without parallelism
+                abacus -> withContext(defaultDispatcher.limitedParallelism(1)) { block() }
+                network -> withContext(ioDispatcher) { block() }
+            }
         }
     }
 }

--- a/v4/integration/javascript/src/main/java/exchange/dydx/integration/javascript/JavascriptRunnerV4.kt
+++ b/v4/integration/javascript/src/main/java/exchange/dydx/integration/javascript/JavascriptRunnerV4.kt
@@ -8,7 +8,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import exchange.dydx.trading.common.AppConfig
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -21,6 +20,7 @@ val LOGGER = if (DO_LOG) Timber.tag(TAG) else null
 class JavascriptRunnerV4 constructor(
     private val scriptDescription: String,
     private val scriptInitializationCode: String,
+    private val scope: CoroutineScope,
 ) : JavascriptRunner {
 
     override val initialized = MutableStateFlow(false)
@@ -29,12 +29,13 @@ class JavascriptRunnerV4 constructor(
 
     companion object {
         fun runnerFromFile(
+            scope: CoroutineScope,
             context: Context,
             file: String,
         ): JavascriptRunnerV4? {
             val script = JavascriptUtils.loadAsset(context, file)
             if (script != null) {
-                return JavascriptRunnerV4(file, script)
+                return JavascriptRunnerV4(file, script, scope)
             }
             return null
         }
@@ -121,7 +122,7 @@ class JavascriptRunnerV4 constructor(
 
     val pattern = Pattern.compile("""^"(.*)"\$""")
     private fun launchJs(script: String, callback: ResultCallback) {
-        CoroutineScope(Main).launch {
+        scope.launch {
             webappInterface.callback = callback
             val localWebview = webview
             if (localWebview == null) {

--- a/v4/integration/starkex/src/main/java/exchange/dydx/integration/starkex/StarkexLib.kt
+++ b/v4/integration/starkex/src/main/java/exchange/dydx/integration/starkex/StarkexLib.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import exchange.dydx.integration.javascript.JavascriptApiImpl
 import exchange.dydx.integration.javascript.JavascriptRunnerV3
+import exchange.dydx.trading.common.di.CoroutineScopes
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import java.io.IOException
@@ -14,11 +16,12 @@ private const val STARKEX_FILENAME: String = "starkex-lib.js"
 @ActivityRetainedScoped
 class StarkexLib @Inject constructor(
     application: Application,
+    @CoroutineScopes.App appScope: CoroutineScope,
 ) :
     JavascriptApiImpl(
         context = application,
         description = STARKEX_FILENAME,
-        runner = JavascriptRunnerV3.runnerFromFile(application, STARKEX_FILENAME)
+        runner = JavascriptRunnerV3.runnerFromFile(appScope, application, STARKEX_FILENAME)
             ?: throw IOException("Fatal, unable to load runner from: $STARKEX_FILENAME"),
     ) {
 
@@ -60,9 +63,10 @@ private const val STARKEX_ETH_FILENAME: String = "starkex-eth.js"
 @ActivityRetainedScoped
 class StarkexEth @Inject constructor(
     application: Application,
+    @CoroutineScopes.App appScope: CoroutineScope,
 ) : JavascriptApiImpl(
     context = application,
     description = STARKEX_ETH_FILENAME,
-    runner = JavascriptRunnerV3.runnerFromFile(application, STARKEX_ETH_FILENAME)
+    runner = JavascriptRunnerV3.runnerFromFile(appScope, application, STARKEX_ETH_FILENAME)
         ?: throw IOException("Fatal, unable to load runner from: $STARKEX_ETH_FILENAME"),
 )

--- a/v4/platformUI/src/main/java/exchange/dydx/platformui/components/PlatformInfo.kt
+++ b/v4/platformUI/src/main/java/exchange/dydx/platformui/components/PlatformInfo.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.graphics.Color
 import exchange.dydx.platformui.designSystem.theme.ThemeColor
 import exchange.dydx.platformui.designSystem.theme.color
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonNull.content
@@ -53,7 +52,8 @@ fun PlatformInfoScaffold(
 
 data class PlatformInfo(
     internal val snackbarHostState: SnackbarHostState,
-    internal val infoType: MutableStateFlow<InfoType>
+    internal val infoType: MutableStateFlow<InfoType>,
+    private val appScope: CoroutineScope,
 ) {
     enum class InfoType {
         Error, Info, Warning;
@@ -82,7 +82,7 @@ data class PlatformInfo(
         duration: SnackbarDuration = SnackbarDuration.Short,
     ) {
         infoType.value = type
-        CoroutineScope(Dispatchers.Main).launch {
+        appScope.launch {
             val result = snackbarHostState.showSnackbar(
                 message = if (title.isNullOrBlank()) message else title + "\n" + message,
                 actionLabel = buttonTitle,


### PR DESCRIPTION
This PR introduces two new sets of objects to the Dagger graph:
- A set of shared coroutine scopes, with Dagger qualifiers: `@CoroutineScopes.App` and `@CoroutineScopes.ViewModel`
- A set of dispatchers: `@CoroutineDispatchers.Main`, `@CoroutineDispatchers.IO`, `@CoroutineDispatchers.Default`

It is best practice to pass in scopes and dispatchers rather than hardcoding (dependency inversion), so that in tests we can use test coroutine scopes and test dispatchers. Also, `Dispatchers.Main` is not setup by default in tests, and therefore requires extra setup that slows down test execution.

Additionally, if we are not using shared scopes, then we are not utilizing structured concurrency -- and are therefore potentially leaking objects (since we aren't canceling our one-off scopes appropriately). 
- On this note, make sure to use `@CoroutineScopes.ViewModel` in ViewModels, as it has been configured to cancel when the ViewModel ends its lifecycle. (DO NOT USE AndroidX's `viewModelScope` -- it violates dependency inversion and is also hardcoded to use Dispatchers.Main, which as discussed above makes testing a pain.)
  