### PR TITLE
Fix margin issues with portfolio position items

### DIFF
--- a/v4/feature/portfolio/src/main/java/exchange/dydx/trading/feature/portfolio/components/positions/DydxPortfolioPositionItemView.kt
+++ b/v4/feature/portfolio/src/main/java/exchange/dydx/trading/feature/portfolio/components/positions/DydxPortfolioPositionItemView.kt
@@ -65,12 +65,12 @@ object DydxPortfolioPositionItemView {
         Row(
             modifier = modifier
                 .padding(
-                    // outer padding first, before widht and height
+                    // outer padding first, before width and height
                     horizontal = ThemeShapes.HorizontalPadding,
                     vertical = ThemeShapes.VerticalPadding,
                 )
                 .fillMaxWidth()
-                .height((if (isIsolatedMarketEnabled) 148.dp else 64.dp) + ThemeShapes.VerticalPadding * 2)
+                .height((if (isIsolatedMarketEnabled) 148.dp else 48.dp) + ThemeShapes.VerticalPadding * 2)
                 .background(
                     brush = position.gradientType.brush(ThemeColor.SemanticColor.layer_3),
                     shape = shape,

--- a/v4/feature/portfolio/src/main/java/exchange/dydx/trading/feature/portfolio/components/positions/DydxPortfolioPositionsView.kt
+++ b/v4/feature/portfolio/src/main/java/exchange/dydx/trading/feature/portfolio/components/positions/DydxPortfolioPositionsView.kt
@@ -3,7 +3,6 @@ package exchange.dydx.trading.feature.portfolio.components.positions
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -66,8 +65,10 @@ object DydxPortfolioPositionsView : DydxComponent {
         val viewModel: DydxPortfolioPositionsViewModel = hiltViewModel()
 
         val state = viewModel.state.collectAsStateWithLifecycle(initialValue = null).value
-        LazyColumn {
-            ListContent(this, modifier, state)
+        LazyColumn(
+            modifier = modifier,
+        ) {
+            ListContent(this, Modifier, state)
         }
     }
 
@@ -76,28 +77,28 @@ object DydxPortfolioPositionsView : DydxComponent {
 
         if (state.positions.isEmpty()) {
             scope.item(key = "placeholder") {
-                DydxPortfolioPlaceholderView.Content(modifier.padding(vertical = 0.dp))
+                DydxPortfolioPlaceholderView.Content(Modifier.padding(vertical = 0.dp))
             }
         } else {
             if (!state.isIsolatedMarketEnabled) {
                 scope.item(key = "header") {
-                    CreateHeader(modifier, state)
+                    CreateHeader(Modifier, state)
                 }
             }
 
             scope.items(items = state.positions, key = { it.id }) { position ->
-                if (!state.isIsolatedMarketEnabled && position === state.positions.first()) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
+//                if (!state.isIsolatedMarketEnabled && position === state.positions.first()) {
+//                    Spacer(modifier = Modifier.height(16.dp))
+//                }
                 DydxPortfolioPositionItemView.Content(
-                    modifier = modifier,
+                    modifier = Modifier,
                     localizer = state.localizer,
                     position = position,
                     isIsolatedMarketEnabled = state.isIsolatedMarketEnabled,
                     onTapAction = state.onPositionTapAction,
                 )
 
-                Spacer(modifier = Modifier.height(10.dp))
+//              Spacer(modifier = Modifier.height(10.dp))
             }
         }
     }


### PR DESCRIPTION
Recent changes for isolated margin introduced incorrect margins to the portfolio position items.  This PR fixes them, and the screenshots after the fix can be viewed below:


**Without isolated margin (i.e., current production version):**

![Screenshot_1712851363](https://github.com/dydxprotocol/v4-native-android/assets/102453770/cccb4d9d-712e-40f3-96f1-dc72d4b6a833)

**Isolated margin feature flag on:**

![Screenshot_1712851297](https://github.com/dydxprotocol/v4-native-android/assets/102453770/37152901-dcde-4041-8041-26c8fefc8143)
