### PR TITLE
Fix an issue of order/fill status display

### DIFF
--- a/v4/feature/portfolio/src/main/java/exchange/dydx/trading/feature/portfolio/orderdetails/DydxOrderDetailsViewModel.kt
+++ b/v4/feature/portfolio/src/main/java/exchange/dydx/trading/feature/portfolio/orderdetails/DydxOrderDetailsViewModel.kt
@@ -52,11 +52,11 @@ class DydxOrderDetailsViewModel @Inject constructor(
             abacusStateManager.state.marketMap,
             abacusStateManager.state.assetMap,
         ) { fills, orders, marketMap, assetMap ->
-            if (fills == null || orders == null || marketMap == null || assetMap == null) {
+            if (marketMap == null || assetMap == null) {
                 return@combine null
             }
-            val fill = fills.firstOrNull { it.id == orderOrFillId }
-            val order = orders.firstOrNull { it.id == orderOrFillId }
+            val fill = fills?.firstOrNull { it.id == orderOrFillId }
+            val order = orders?.firstOrNull { it.id == orderOrFillId }
             if (fill != null) {
                 createFillViewState(fill, marketMap, assetMap)
             } else if (order != null) {


### PR DESCRIPTION
The previous implementation requires both `fills` and `orders` to exist, but in fact we should show if either exists.