### PR TITLE
Fix dollar() formatting crash in FR locale.

### DIFF
--- a/v4/common/src/main/java/exchange/dydx/trading/common/formatter/DydxFormatter.kt
+++ b/v4/common/src/main/java/exchange/dydx/trading/common/formatter/DydxFormatter.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.trading.common.formatter
 
 import java.math.BigDecimal
+import java.math.BigDecimal.ZERO
 import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
@@ -149,8 +150,8 @@ class DydxFormatter @Inject constructor() {
         if (number == null) return null
         val formattedNumber = localFormatted(number.abs(), digits)
         return formattedNumber?.let {
-            val rawDouble = raw(number.toDouble(), digits)?.toDouble() ?: 0.0
-            if (rawDouble >= 0.0) {
+            val rounded = number.setScale(digits, RoundingMode.HALF_UP)
+            if (rounded >= BigDecimal.ZERO) {
                 "$$it"
             } else {
                 "-$$it"

--- a/v4/common/src/test/java/exchange/dydx/common/formatter/DydxFormatterTests.kt
+++ b/v4/common/src/test/java/exchange/dydx/common/formatter/DydxFormatterTests.kt
@@ -97,6 +97,7 @@ class DydxFormatterTests {
             val number: Double,
             val digits: Int = 2,
             val expected: String,
+            val locale: Locale = Locale.US,
         )
 
         val testCases = listOf(
@@ -108,9 +109,18 @@ class DydxFormatterTests {
             TestCase(number = 0.0, digits = 0, expected = "$0"),
             TestCase(number = 0.0, digits = 1, expected = "$0.0"),
             TestCase(number = 0.6, digits = 0, expected = "$1"),
+            TestCase(number = 1.0, digits = 2, expected = "$1,00", locale = Locale.FRANCE),
+            TestCase(number = 0.5, digits = 2, expected = "$0,50", locale = Locale.FRANCE),
+            TestCase(number = -0.25, digits = 2, expected = "-$0,25", locale = Locale.FRANCE),
+            TestCase(number = -0.0002, digits = 2, expected = "$0,00", locale = Locale.FRANCE),
+            TestCase(number = 0.0, digits = 2, expected = "$0,00", locale = Locale.FRANCE),
+            TestCase(number = 0.0, digits = 0, expected = "$0", locale = Locale.FRANCE),
+            TestCase(number = 0.0, digits = 1, expected = "$0,0", locale = Locale.FRANCE),
+            TestCase(number = 0.6, digits = 0, expected = "$1", locale = Locale.FRANCE),
         )
 
         testCases.forEach { testCase ->
+            formatter.locale = testCase.locale
             val formatted = formatter.dollar(number = testCase.number, digits = testCase.digits)
             assert(formatted == testCase.expected) { "Test case: $testCase, formatted: $formatted" }
         }


### PR DESCRIPTION
https://console.firebase.google.com/project/dydx-operations-services/crashlytics/app/android:trade.opsdao.dydxchain/issues/45e9e2b4cfef1b15af685bc4b94cd769?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_ISSUE&time=last-seven-days&sessionEventKey=662007A4019200012CDAE9BC341AD293_1937336057674736643