### PR TITLE
Made localizer a computed property

### DIFF
--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusLocalizerImp.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusLocalizerImp.kt
@@ -37,7 +37,8 @@ class AbacusLocalizerImp @Inject constructor(
         }
     }
 
-    private val localizer = UIImplementationsExtensions.shared?.localizer as? DynamicLocalizer
+    private val localizer: DynamicLocalizer?
+        get() = UIImplementationsExtensions.shared?.localizer as? DynamicLocalizer
 
     override val languages: List<SelectionOption>
         get() {


### PR DESCRIPTION
Otherwise with the current startup sequence, it's always set to null because UIImplementationsExtensions.shared?.localizer is null at initialization. 