### PR TITLE
Fixing threading issues

### DIFF
--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusThreadingImp.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/AbacusThreadingImp.kt
@@ -10,7 +10,6 @@ import exchange.dydx.trading.common.di.CoroutineScopes
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.invoke
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import javax.inject.Inject


### PR DESCRIPTION
scope.launch(dispatcher) {} doesn't seem to guarantee limited parallelism (and/or FIFO scheduling), so let's revert back to the previous implementation.

The app would occasionally throw "ConcurrentWriteException".  In addition, at app launch the Portfolio "Trades" tab would sometimes be empty even when there are trades.  What happens is that Abacus has multiple updates to the state but the updates are not scheduled to run in the FIFO order, so that trades are incorrectly overwritten .