### PR TITLE
Turn on Kotlin incremental classpath snapshots.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 
 org.gradle.parallel=true
 org.gradle.caching=true
+# compilation avoidance for non public code changes
+kotlin.incremental.useClasspathSnapshot=true 
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK


### PR DESCRIPTION
https://blog.jetbrains.com/kotlin/2022/07/a-new-approach-to-incremental-compilation-in-kotlin/

This was originally released in Kotlin 1.7.0, but was finally fixed and working in 1.9.20: https://youtrack.jetbrains.com/issue/KT-51964/Optimize-kotlin.incremental.useClasspathSnapshot-feature-to-improve-incremental-Kotlin-compilation

This should be good for us since we don't have an `api` vs `implementation` split in our Gradle modules. But does mean we should start being more proactive about using `internal` visibility instead of relying on default `public`.