### PR TITLE
Fix market info's stats/about tab animation issue

### DIFF
--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/DydxMarketInfoView.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/DydxMarketInfoView.kt
@@ -1,5 +1,8 @@
 package exchange.dydx.trading.feature.market.marketinfo
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -155,11 +158,23 @@ object DydxMarketInfoView : DydxComponent {
                         )
                     }
                     item(key = "stats") {
-                        when (state.statsTabSelection) {
-                            DydxMarketStatsTabView.Selection.Statistics -> {
-                                DydxMarketStatsView.Content(Modifier)
-                            }
-                            DydxMarketStatsTabView.Selection.About -> {
+                        AnimatedVisibility(
+                            visible =
+                            state.statsTabSelection == DydxMarketStatsTabView.Selection.Statistics,
+                            enter = expandVertically(),
+                            exit = shrinkVertically(),
+                        ) {
+                            DydxMarketStatsView.Content(Modifier)
+                        }
+                        AnimatedVisibility(
+                            visible =
+                            state.statsTabSelection == DydxMarketStatsTabView.Selection.About,
+                            enter = expandVertically(),
+                            exit = shrinkVertically(),
+                        ) {
+                            Column(
+                                modifier = Modifier,
+                            ) {
                                 DydxMarketResourcesView.Content(Modifier)
                                 Spacer(modifier = Modifier.height(ThemeShapes.VerticalPadding))
                                 DydxMarketConfigsView.Content(Modifier)


### PR DESCRIPTION
Fixing the issue of unexpected scroll position after tab change.

Before:
[animation_old.webm](https://github.com/dydxprotocol/v4-native-android/assets/102453770/61739495-03ea-4514-8623-d0783073dd5b)


After:
[animation_new.webm](https://github.com/dydxprotocol/v4-native-android/assets/102453770/4bdebd35-6953-40ad-a2b8-f83c15f6dc43)
