### PR TITLE
MOB-468: Clean up market prices chart

### DIFF
--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DateTimeAxisFormatter.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DateTimeAxisFormatter.kt
@@ -11,7 +11,7 @@ class DateTimeAxisFormatter(
     private val offset: Int,
 ) : ValueAxisFormatter() {
     private val minuteFormatter = DateTimeFormatter.ofPattern("HH:mm")
-    private val hourFormatter = DateTimeFormatter.ofPattern("HH")
+    private val hourFormatter = DateTimeFormatter.ofPattern("HH:mm")
     private val dayFormatter = DateTimeFormatter.ofPattern("MMM dd", Locale.ENGLISH)
 
     override fun getFormattedValue(value: Float): String {
@@ -49,11 +49,11 @@ class DateTimeAxisFormatter(
             }
         }.atZone(java.time.ZoneId.systemDefault()).toLocalDateTime()
         return when (candlesPeriod) {
-            "1DAY" -> {
+            "1DAY", "4HOURS" -> {
                 datetime.format(dayFormatter)
             }
 
-            "1HOUR", "4HOURS" -> {
+            "1HOUR" -> {
                 datetime.format(hourFormatter)
             }
 

--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesView.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesView.kt
@@ -129,8 +129,6 @@ object DydxMarketPricesView : DydxComponent {
         }
     }
 
-    private var market: String? = null
-
     @Composable
     override fun Content(modifier: Modifier) {
         val viewModel: DydxMarketPricesViewModel = hiltViewModel()
@@ -361,26 +359,22 @@ object DydxMarketPricesView : DydxComponent {
                     .fillMaxHeight(),
                 update = { chart ->
                     chart.update(
-                        if (state.typeOptions.index == 0) state.candles else null,
-                        state.volumes,
-                        if (state.typeOptions.index == 0) null else state.prices,
-                        state.orderLines,
-                        state.config,
-                        null,
+                        candles = if (state.typeOptions.index == 0) state.candles else null,
+                        bars = state.volumes,
+                        line = if (state.typeOptions.index == 0) null else state.prices,
+                        limits = state.orderLines,
+                        config = state.config,
+                        lineColor = null,
                     ) { lastX ->
-                        if (market != state.market) {
-                            // Show 40 items
-                            chart.data.barData.dataSets.firstOrNull()?.xMax?.let {
-                                chart.setVisibleXRange(40f, 40f)
-                                chart.moveViewToX(lastX)
-                                // The minXRange has a higher number than maxXRange
-                                // because the minXRange is the range for minXScale
-                                // and the maxXRange is the range for maxXScale
-                                // and range and scale are inverse
-                                chart.setVisibleXRange(160f, 40f)
-                            }
-                            market = state.market
-                        }
+                        // Show 40 items
+                        chart.setVisibleXRange(40f, 40f)
+                        chart.moveViewToX(lastX)
+                        //        chart.moveViewToAnimated(lastX, 0f, YAxis.AxisDependency.RIGHT, 500)
+                        // The minXRange has a higher number than maxXRange
+                        // because the minXRange is the range for minXScale
+                        // and the maxXRange is the range for maxXScale
+                        // and range and scale are inverse
+                        chart.setVisibleXRange(160f, 40f)
                     }
                 },
             )

--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/PriceAxisFormatter.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/PriceAxisFormatter.kt
@@ -3,7 +3,10 @@ package exchange.dydx.trading.feature.market.marketinfo.components.prices
 import exchange.dydx.platformui.components.charts.formatter.ValueAxisFormatter
 import exchange.dydx.trading.common.formatter.DydxFormatter
 
-class PriceAxisFormatter(private val formatter: DydxFormatter, private val tickSizeDecimals: Int) : ValueAxisFormatter() {
+class PriceAxisFormatter(
+    private val formatter: DydxFormatter,
+    private val tickSizeDecimals: Int
+) : ValueAxisFormatter() {
     override fun getFormattedValue(value: Float): String {
         return formatter.dollar(value.toDouble(), tickSizeDecimals) ?: ""
     }


### PR DESCRIPTION
- Setting the viewport correctly.
- Updating the x-axis content correctly.
- Setting the default period to 1 hour.

There is some jitter when during data load, but there is no easy way to around it (same with iOS).

[untitled.webm](https://github.com/dydxprotocol/v4-native-android/assets/102453770/006d3283-b916-4b33-a840-abe5cf0813d6)
