### PR TITLE
MOB-470 MOB-471 Add order line annotations.

### DIFF
--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesView.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesView.kt
@@ -1,5 +1,12 @@
 package exchange.dydx.trading.feature.market.marketinfo.components.prices
 
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.Typeface
+import androidx.annotation.ColorInt
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -28,6 +36,7 @@ import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.data.CandleEntry
 import com.github.mikephil.charting.data.Entry
+import exchange.dydx.abacus.output.input.OrderSide
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.platformui.components.buttons.PlatformPillItem
 import exchange.dydx.platformui.components.charts.config.CombinedChartConfig
@@ -41,7 +50,10 @@ import exchange.dydx.platformui.components.tabgroups.PlatformPillTextGroup
 import exchange.dydx.platformui.designSystem.theme.ThemeColor
 import exchange.dydx.platformui.designSystem.theme.ThemeFont
 import exchange.dydx.platformui.designSystem.theme.ThemeShapes
+import exchange.dydx.platformui.designSystem.theme.color
 import exchange.dydx.platformui.designSystem.theme.dydxDefault
+import exchange.dydx.platformui.designSystem.theme.negativeColor
+import exchange.dydx.platformui.designSystem.theme.positiveColor
 import exchange.dydx.platformui.designSystem.theme.themeColor
 import exchange.dydx.platformui.designSystem.theme.themeFont
 import exchange.dydx.trading.common.component.DydxComponent
@@ -80,7 +92,7 @@ object DydxMarketPricesView : DydxComponent {
         val candles: CandleChartDataSet?,
         val volumes: BarDataSet?,
         val prices: LineChartDataSet?,
-        val orderLines: List<LimitLine>,
+        val orderLines: List<OrderData>,
         val typeOptions: SelectionOptions,
         val resolutionOptions: SelectionOptions,
         val highlight: PriceHighlight? = null,
@@ -115,7 +127,7 @@ object DydxMarketPricesView : DydxComponent {
                     "funding",
                 ),
                 listOf(
-                    LimitLine(1f),
+                    OrderData(1.0, OrderSide.buy, 1.0),
                 ),
                 typeOptions = SelectionOptions(
                     titles = listOf("Candles", "Lines"),
@@ -350,7 +362,7 @@ object DydxMarketPricesView : DydxComponent {
         ) {
             AndroidView(
                 factory = { context ->
-                    CombinedChart(context).apply {
+                    CombinedChartWithOrderLines(context).apply {
                         config(state.config)
                     }
                 },
@@ -358,11 +370,11 @@ object DydxMarketPricesView : DydxComponent {
                     .fillMaxWidth()
                     .fillMaxHeight(),
                 update = { chart ->
+                    chart.orderLines = state.orderLines
                     chart.update(
                         candles = if (state.typeOptions.index == 0) state.candles else null,
                         bars = state.volumes,
                         line = if (state.typeOptions.index == 0) null else state.prices,
-                        limits = state.orderLines,
                         config = state.config,
                         lineColor = null,
                     ) { lastX ->
@@ -381,3 +393,122 @@ object DydxMarketPricesView : DydxComponent {
         }
     }
 }
+
+internal class CombinedChartWithOrderLines(context: Context) : CombinedChart(context) {
+
+    var orderLines: List<OrderData> = emptyList()
+        set(value) {
+            field = value
+            axisLeft.removeAllLimitLines()
+            value.forEach { (price, side) ->
+                LimitLine(price.toFloat())
+                    .apply {
+                        lineColor = side.orderLineColor
+                        textColor = side.orderLineTextColor
+                        enableDashedLine(20f, 10f, 0f)
+                    }
+                    .also { axisLeft.addLimitLine(it) }
+            }
+        }
+    override fun draw(canvas: Canvas) {
+        super.draw(canvas)
+
+        orderLines.forEach { orderLine ->
+            // calculate y pixel value for the orderline
+            val orderPixelY = run {
+                val floatArray = floatArrayOf(0f, orderLine.price.toFloat())
+                mLeftAxisTransformer.pointValuesToPixel(floatArray)
+                floatArray[1]
+            }
+
+            val tagRightX = canvas.drawOrderPriceTag(orderPixelY, orderLine)
+            canvas.drawOrderLabelAndSize(tagRightX + 48f, orderPixelY, orderLine)
+        }
+    }
+
+    private fun Canvas.drawOrderPriceTag(yPos: Float, orderLine: OrderData): Float {
+        return drawTextView(
+            xPos = 0f,
+            yPos = yPos,
+            text = "\$${orderLine.price}",
+            backgroundColor = orderLine.side.orderLineColor,
+            textColor = orderLine.side.orderLineTextColor,
+        )
+    }
+
+    private fun Canvas.drawOrderLabelAndSize(xPos: Float, yPos: Float, orderLine: OrderData) {
+        val orderLabelRight = drawOrderLabel(xPos, yPos)
+        drawOrderSize(orderLabelRight, yPos, orderLine)
+    }
+
+    private fun Canvas.drawOrderLabel(xPos: Float, yPos: Float): Float {
+        return drawTextView(
+            xPos = xPos,
+            yPos = yPos,
+            text = "Limit Order",
+            backgroundColor = Color.parseColor("#18181B"),
+            textColor = Color.parseColor("#807E98"),
+        )
+    }
+
+    private fun Canvas.drawOrderSize(xPos: Float, yPos: Float, orderLine: OrderData) {
+        drawTextView(
+            xPos = xPos,
+            yPos = yPos,
+            text = "${orderLine.size}",
+            backgroundColor = orderLine.side.orderLineColor,
+            textColor = orderLine.side.orderLineTextColor,
+            horizontalPadding = 12f,
+        )
+    }
+
+    private fun Canvas.drawTextView(
+        xPos: Float,
+        yPos: Float,
+        text: String,
+        @ColorInt backgroundColor: Int,
+        @ColorInt textColor: Int,
+        verticalPadding: Float = 12f,
+        horizontalPadding: Float = 24f,
+    ): Float {
+        val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = backgroundColor
+        }
+
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = textColor
+            textSize = 30f
+            textAlign = Paint.Align.LEFT
+            typeface = Typeface.DEFAULT_BOLD
+        }
+
+        val textWidth = textPaint.measureText(text)
+        val textHeight = textPaint.descent() - textPaint.ascent()
+
+        val top = yPos - (textHeight / 2) - verticalPadding
+        val right = xPos + textWidth + (horizontalPadding * 2)
+        val bottom = yPos + (textHeight / 2) + verticalPadding
+
+        drawRect(Rect(xPos.toInt(), top.toInt(), right.toInt(), bottom.toInt()), backgroundPaint)
+        drawText(
+            text,
+            xPos + horizontalPadding,
+            yPos + textHeight / 2 + textPaint.descent() / 2 - verticalPadding,
+            textPaint,
+        )
+
+        return right
+    }
+}
+
+private val OrderSide.orderLineColor: Int
+    get() = when (this) {
+        OrderSide.buy -> ThemeColor.SemanticColor.positiveColor.color.toArgb()
+        OrderSide.sell -> ThemeColor.SemanticColor.negativeColor.color.toArgb()
+    }
+
+private val OrderSide.orderLineTextColor: Int
+    get() = when (this) {
+        OrderSide.buy -> ThemeColor.SemanticColor.color_black.color.toArgb()
+        OrderSide.sell -> ThemeColor.SemanticColor.color_white.color.toArgb()
+    }

--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesViewModel.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesViewModel.kt
@@ -2,7 +2,6 @@ package exchange.dydx.trading.feature.market.marketinfo.components.prices
 
 import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.ViewModel
-import com.github.mikephil.charting.components.LimitLine
 import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.data.CandleDataSet
@@ -115,7 +114,7 @@ class DydxMarketPricesViewModel @Inject constructor(
             val prices = allPrices?.candles?.get(candlesPeriod)
             val orderData = ordersForMarket?.run {
                 filter { it.status in listOf(OrderStatus.open, OrderStatus.untriggered, OrderStatus.partiallyFilled) }
-                    .map { OrderData(it.price, it.side) }
+                    .map { OrderData(it.price, it.side, it.remainingSize ?: it.size) }
             }.orEmpty()
             createViewState(
                 prices = prices,
@@ -218,16 +217,7 @@ class DydxMarketPricesViewModel @Inject constructor(
             candles = CandleDataSet(candles, "candles"),
             volumes = BarDataSet(volumes, "volumes"),
             prices = LineChartDataSet(lines, "lines"),
-            orderLines = orderData.map { (price, side) ->
-                LimitLine(price.toFloat())
-                    .apply {
-                        lineColor = when (side) {
-                            OrderSide.buy -> SemanticColor.positiveColor.color.toArgb()
-                            OrderSide.sell -> SemanticColor.negativeColor.color.toArgb()
-                        }
-                        enableDashedLine(20f, 10f, 0f)
-                    }
-            },
+            orderLines = orderData,
             typeOptions = SelectionOptions(
                 typeTitles,
                 typeIndex,
@@ -374,7 +364,8 @@ class DydxMarketPricesViewModel @Inject constructor(
     }
 }
 
-private data class OrderData(
+data class OrderData(
     val price: Double,
-    val side: OrderSide
+    val side: OrderSide,
+    val size: Double,
 )

--- a/v4/platformUI/src/main/java/exchange/dydx/platformui/components/charts/view/Combined.kt
+++ b/v4/platformUI/src/main/java/exchange/dydx/platformui/components/charts/view/Combined.kt
@@ -2,7 +2,6 @@ package exchange.dydx.platformui.components.charts.view
 
 import com.github.mikephil.charting.charts.BarLineChartBase
 import com.github.mikephil.charting.charts.CombinedChart
-import com.github.mikephil.charting.components.LimitLine
 import com.github.mikephil.charting.data.BarData
 import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarLineScatterCandleBubbleData
@@ -110,7 +109,6 @@ fun CombinedChart.update(
     candles: CandleChartDataSet?,
     bars: BarDataSet?,
     line: LineChartDataSet?,
-    limits: List<LimitLine>,
     config: ICombinedChartConfig,
     lineColor: Int? = null,
     updateRange: (lastX: Float) -> Unit = {}
@@ -164,11 +162,6 @@ fun CombinedChart.update(
         if (lastValue != null) {
             updateRange(lastValue)
         }
-    }
-
-    axisLeft.removeAllLimitLines()
-    limits.forEach {
-        axisLeft.addLimitLine(it)
     }
 
     notifyDataSetChanged()


### PR DESCRIPTION
![Screenshot 2024-05-03 at 4 01 36 PM](https://github.com/dydxprotocol/v4-native-android/assets/163016611/131d2563-4cc3-4aad-b857-4293759ba31a)

Creates a new custom subclass of `CombinedChart` that supports adding order lines. It overrides `draw()` to do additional drawing of order line annotations.

Does not include localization or formatting, will tackle in a follow up.