### PR TITLE
MOB-513 Clean up force update logic

### DIFF
--- a/v4/common/src/main/java/exchange/dydx/trading/common/navigation/DydxRouter.kt
+++ b/v4/common/src/main/java/exchange/dydx/trading/common/navigation/DydxRouter.kt
@@ -23,6 +23,8 @@ interface DydxRouter {
         Default,
     }
 
+    val initialized: StateFlow<Boolean>
+
     fun presentation(route: String): Presentation
     fun isParentChild(parent: String, child: String): Boolean
 
@@ -31,6 +33,7 @@ interface DydxRouter {
     fun tabTo(route: String, restoreState: Boolean = true)
 
     fun navigateBack()
+    fun navigateToRoot(excludeRoot: Boolean)
     fun requireNavController(): NavHostController
     fun initialize(navHostController: NavHostController)
 

--- a/v4/core/src/main/java/exchange/dydx/trading/core/DydxRouterImpl.kt
+++ b/v4/core/src/main/java/exchange/dydx/trading/core/DydxRouterImpl.kt
@@ -18,6 +18,7 @@ import exchange.dydx.trading.common.navigation.MarketRoutes
 import exchange.dydx.trading.integration.analytics.tracking.Tracking
 import exchange.dydx.utilities.utils.Logging
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 private const val TAG = "DydxRouterImpl"
@@ -115,7 +116,11 @@ class DydxRouterImpl @Inject constructor(
         logger.d(TAG, "DydxRouter initialized")
         this.navHostController = navHostController
         navHostController.addOnDestinationChangedListener(destinationChangedListener)
+        _initialized.value = true
     }
+
+    private val _initialized = MutableStateFlow(false)
+    override val initialized: StateFlow<Boolean> = _initialized
 
     override val destinationFlow: MutableStateFlow<Destination?> = MutableStateFlow(null)
 
@@ -166,7 +171,15 @@ class DydxRouterImpl @Inject constructor(
 
     override fun navigateBack() {
         routeQueue.removeLast()
-        navHostController?.popBackStack()
+        navHostController.popBackStack()
+    }
+
+    override fun navigateToRoot(excludeRoot: Boolean) {
+        routeQueue.clear()
+        navHostController.popBackStack(
+            destinationId = navHostController.graph.findStartDestination().id,
+            inclusive = excludeRoot,
+        )
     }
 
     override fun requireNavController(): NavHostController {

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/DydxGlobalWorkers.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/DydxGlobalWorkers.kt
@@ -39,7 +39,7 @@ class DydxGlobalWorkers(
 ) : WorkerProtocol {
 
     private val workers = listOf(
-        DydxUpdateWorker(scope, abacusStateManager, router, context),
+        DydxUpdateWorker(scope, abacusStateManager, router, context, logger),
         DydxAlertsWorker(scope, abacusStateManager, localizer, router, platformInfo, preferencesStore),
         DydxApiStatusWorker(scope, abacusStateManager, localizer, platformInfo),
         DydxRestrictionsWorker(scope, abacusStateManager, localizer, platformInfo),

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxUpdateWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxUpdateWorker.kt
@@ -5,19 +5,27 @@ import exchange.dydx.abacus.state.manager.V4Environment
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.trading.common.navigation.DydxRouter
 import exchange.dydx.trading.common.navigation.ProfileRoutes
+import exchange.dydx.utilities.utils.Logging
 import exchange.dydx.utilities.utils.VersionUtils
 import exchange.dydx.utilities.utils.WorkerProtocol
+import exchange.dydx.utilities.utils.delayFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlin.time.Duration.Companion.seconds
+
+private const val TAG = "DydxUpdateWorker"
 
 class DydxUpdateWorker(
     override val scope: CoroutineScope,
     private val abacusStateManager: AbacusStateManagerProtocol,
     private val router: DydxRouter,
     private val context: Context,
+    private val logger: Logging,
 ) : WorkerProtocol {
     override var isStarted = false
 
@@ -25,12 +33,21 @@ class DydxUpdateWorker(
         if (!isStarted) {
             isStarted = true
 
-            abacusStateManager.currentEnvironmentId
+            router.initialized
+                .filter { it }
+                .flatMapLatest {
+                    // Wait 2 seconds for the root view to load first.  Otherwise, "/portfolio/" would take
+                    // place after "/update"
+                    delayFlow(duration = 2.seconds)
+                }
+                .flatMapLatest { abacusStateManager.currentEnvironmentId }
                 .mapNotNull { it }
                 .distinctUntilChanged()
                 .onEach {
                     abacusStateManager.environment?.let {
                         update(it)
+                    } ?: run {
+                        logger.e(TAG, "Environment is null")
                     }
                 }
                 .launchIn(scope)
@@ -43,10 +60,11 @@ class DydxUpdateWorker(
         }
     }
 
-    private fun update(environment: V4Environment?) {
-        val desired = environment?.apps?.android?.build ?: return
+    private fun update(environment: V4Environment) {
+        val desired = environment.apps?.android?.build ?: return
         val mine = VersionUtils.versionCode(context) ?: return
         if (desired > mine) {
+            router.navigateToRoot(excludeRoot = true)
             router.navigateTo(ProfileRoutes.update)
         }
     }

--- a/v4/utilities/src/main/java/exchange/dydx/utilities/utils/TimerFlow.kt
+++ b/v4/utilities/src/main/java/exchange/dydx/utilities/utils/TimerFlow.kt
@@ -11,3 +11,8 @@ fun timerFlow(period: Duration, initialDelay: Duration = Duration.ZERO) = flow {
         delay(period)
     }
 }
+
+fun delayFlow(duration: Duration) = flow {
+    delay(duration)
+    emit(Unit)
+}


### PR DESCRIPTION
We have the force update screen already but didn't tested it.  This PR updates it with the following

1. Replace the root view with the force update screen, so that user can only exit the app when hitting the back button.
2. Add delay after the router and the root screen has been initialized.

[force_update.webm](https://github.com/dydxprotocol/v4-native-android/assets/102453770/802bd7a6-45e4-47d3-b5f3-3e34e543dd76)
