### PR TITLE
Update vercel.app URL

### DIFF
--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/UIImplementationsExtensions.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/protocolImplementations/UIImplementationsExtensions.kt
@@ -17,7 +17,7 @@ object UIImplementationsExtensions {
             ioImplementations = ioImplementations,
             systemLanguage = systemLanguage ?: "en",
             path = "/config",
-            endpoint = "https://dydx-shared-resources.vercel.app/config",
+            endpoint = "https://dydx-v4-shared-resources.vercel.app/config",
             loadLocalOnly = loadLocalOnly,
         )
 


### PR DESCRIPTION
The deployment URL has changed, so the app needs to point to the new one.