### PR TITLE
Fix crash when navigateBack() is called while queue is empty.

### DIFF
--- a/v4/core/src/main/java/exchange/dydx/trading/core/DydxRouterImpl.kt
+++ b/v4/core/src/main/java/exchange/dydx/trading/core/DydxRouterImpl.kt
@@ -172,8 +172,9 @@ class DydxRouterImpl @Inject constructor(
     }
 
     override fun navigateBack() {
-        routeQueue.removeLast()
-        navHostController.popBackStack()
+        routeQueue.removeLastOrNull()?.also {
+            navHostController.popBackStack()
+        }
     }
 
     override fun navigateToRoot(excludeRoot: Boolean) {


### PR DESCRIPTION
https://console.firebase.google.com/project/dydx-operations-services/crashlytics/app/android:trade.opsdao.dydxchain/issues/04ea9742857327d5887823b9870ca10c?time=last-seven-days&sessionEventKey=6657DA5301580001390E0549D2996DBE_1953049639311973865