### PR TITLE
Turn on useLegacyPackaging to avoid failure to link libsqlcipher.so o…

### DIFF
--- a/v4/app/build.gradle
+++ b/v4/app/build.gradle
@@ -43,6 +43,15 @@ android {
         lint {
             baseline = file("lint-baseline.xml")
         }
+
+        packagingOptions {
+            jniLibs {
+                // Running into UnsatisfiedLinkError on some devices when linking libsqlcipher.so (used by WalletConnect)
+                // https://github.com/sqlcipher/android-database-sqlcipher/issues/635#issuecomment-1782914589
+                useLegacyPackaging = true
+            }
+        }
+
     }
 
     buildTypes {


### PR DESCRIPTION
…n some devices.

crash:
https://console.firebase.google.com/project/dydx-operations-services/crashlytics/app/android:trade.opsdao.dydxchain/issues/c726efcb3000a08b6fddecced6d53000?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_ISSUE&time=last-seven-days&versions=1.1.0%20(37);1.1.0%20(35);1.1.0%20(34);1.2.0%20(38)&sessionEventKey=665ECA8C001C00015D9CD1B6641CC592_1955001547637968481

github issue:
https://github.com/sqlcipher/android-database-sqlcipher/issues/635#issuecomment-1782914589