### PR TITLE
Fix Amplitude event properties with string values.

### DIFF
--- a/v4/integration/analytics/src/main/java/exchange/dydx/trading/integration/analytics/tracking/AmplitudeTracker.kt
+++ b/v4/integration/analytics/src/main/java/exchange/dydx/trading/integration/analytics/tracking/AmplitudeTracker.kt
@@ -2,7 +2,7 @@ package exchange.dydx.trading.integration.analytics.tracking
 
 import com.amplitude.android.Amplitude
 import com.amplitude.android.events.Identify
-import exchange.dydx.utilities.utils.jsonStringToMap
+import exchange.dydx.utilities.utils.jsonStringToRawStringMap
 
 class AmplitudeTracker(
     private val amplitude: Amplitude
@@ -24,7 +24,7 @@ class AmplitudeTracker(
     }
 
     override fun log(event: String, data: String?) {
-        val jsonMap = data?.jsonStringToMap()
+        val jsonMap = data?.jsonStringToRawStringMap()
         amplitude.track(event, jsonMap)
     }
 

--- a/v4/utilities/src/main/java/exchange/dydx/utilities/utils/JsonUtils.kt
+++ b/v4/utilities/src/main/java/exchange/dydx/utilities/utils/JsonUtils.kt
@@ -2,11 +2,18 @@ package exchange.dydx.utilities.utils
 
 import android.content.Context
 import android.util.Log
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 
 object JsonUtils {
+    val json = Json { ignoreUnknownKeys = true }
+
     inline fun <reified T> loadFromAssets(context: Context, fileName: String): T? {
         return try {
             val manager = context.assets
@@ -16,7 +23,7 @@ object JsonUtils {
             inputStream.read(buffer)
             inputStream.close()
             val data = String(buffer)
-            Json { ignoreUnknownKeys = true }.decodeFromString<T>(data)
+            json.decodeFromString<T>(data)
         } catch (e: Exception) {
             Log.e("JsonUtils", "error: $e")
             null
@@ -27,9 +34,44 @@ object JsonUtils {
 fun String.jsonStringToMap(): Map<String, Any>? {
     try {
         val json = Json.parseToJsonElement(this)
-        return json.jsonObject.toMap()
-    } catch (e: Exception) {
+        return json.jsonObject
+    } catch (e: SerializationException) {
         Log.e("JsonUtils", "error: $e")
         return null
+    }
+}
+
+/**
+ * JsonLiterals wrap Strings in quotations, so if we're passing generically to code we don't own (Amplitude),
+ * we'll get extra quotations. Therefore, need to replace any JsonLiterals with isString = true with the
+ * actual content strings.
+ */
+fun String.jsonStringToRawStringMap(): Map<String, Any>? {
+    try {
+        val json = Json.parseToJsonElement(this)
+        return json.jsonObject.toRawStringMap()
+    } catch (e: SerializationException) {
+        Log.e("JsonUtils", "error: $e")
+        return null
+    }
+}
+
+private fun JsonObject.toRawStringMap(): Map<String, Any> {
+    return this.mapValues { (_, value) ->
+        when (value) {
+            is JsonPrimitive -> if (value.isString) value.content else value
+            is JsonObject -> value.toRawStringMap()
+            is JsonArray -> value.map { it.toRawString() }
+            else -> value.toString()
+        }
+    }
+}
+
+private fun JsonElement.toRawString(): Any {
+    return when (this) {
+        is JsonPrimitive -> if (this.isString) this.content else this
+        is JsonObject -> this.toRawStringMap()
+        is JsonArray -> this.map { it.toRawString() }
+        else -> this.toString()
     }
 }

--- a/v4/utilities/src/test/java/exchange/dydx/utilities/JsonUtilsTests.kt
+++ b/v4/utilities/src/test/java/exchange/dydx/utilities/JsonUtilsTests.kt
@@ -1,0 +1,38 @@
+package exchange.dydx.utilities
+
+import exchange.dydx.utilities.utils.jsonStringToRawStringMap
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Test
+
+class JsonUtilsTests {
+
+    @Test fun jsonStringToRawStringMap() {
+        val json =
+            """
+                {
+                  "type": "MARKET",
+                  "size": 10.0,
+                  "nested" : {
+                    "someValue": "SOME-VALUE",
+                    "anotherValue": 25.0
+                  }
+                }
+            """.trimIndent()
+
+        val mapped = json.jsonStringToRawStringMap()!!
+
+        assertEquals(mapped["type"], "MARKET")
+
+        assert(mapped["size"] is JsonPrimitive)
+        assertEquals(mapped["size"].toString(), "10.0")
+
+        assertEquals((mapped["nested"] as Map<String, Any>)["someValue"], "SOME-VALUE")
+
+        assert((mapped["nested"] as Map<String, Any>)["anotherValue"] is JsonPrimitive)
+        assertEquals((mapped["nested"] as Map<String, Any>)["anotherValue"].toString(), "25.0")
+    }
+}
+
+private fun assertEquals(actual: Any?, expected: Any?) {
+    assert(actual == expected) { "$actual != $expected" }
+}


### PR DESCRIPTION
example issue: https://app.amplitude.com/analytics/dydxopsdao/chart/new/emfdfzvk

https://dydx-team.slack.com/archives/C06FR0QLWFJ/p1717679386328429

this PR only fixes analytics event decoding for Amplitude. We are using `jsonStringToMap` for v4-client responses. I'll make a follow up PR to just move these to static typed json deserialization.