### PR TITLE
Fix a race condition on launch that causes mobile wallet issue

### DIFF
--- a/v4/app/build.gradle
+++ b/v4/app/build.gradle
@@ -19,7 +19,7 @@ android {
         minSdkVersion parent.minSdkVersion
         targetSdkVersion parent.targetSdkVersion
         versionCode 11
-        versionName "1.4.0"
+        versionName "1.4.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/v4/feature/onboarding/src/main/java/exchange/dydx/feature/onboarding/connect/DydxOnboardConnectView.kt
+++ b/v4/feature/onboarding/src/main/java/exchange/dydx/feature/onboarding/connect/DydxOnboardConnectView.kt
@@ -91,7 +91,7 @@ object DydxOnboardConnectView : DydxComponent {
                 closeAction = { state.closeButtonHandler?.invoke() },
             )
             Text(
-                text = state.localizer.localize("ONBOARDING.TWO_SIGNATURE_REQUESTS"),
+                text = state.localizer.localize("APP.ONBOARDING.TWO_SIGNATURE_REQUESTS"),
                 style = TextStyle.dydxDefault
                     .themeFont(fontSize = ThemeFont.FontSize.small)
                     .themeColor(ThemeColor.SemanticColor.text_tertiary),

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
@@ -12,6 +12,8 @@ import exchange.dydx.utilities.utils.Logging
 import exchange.dydx.utilities.utils.WorkerProtocol
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 private const val TAG = "DydxCarteraConfigWorker"
 
@@ -38,11 +40,16 @@ class DydxCarteraConfigWorker(
                 }
             }
 
-            abacusStateManager.environment?.let {
-                configureCartera(it)
-            } ?: run {
-                logger.e(TAG, "Environment is null")
-            }
+            abacusStateManager.currentEnvironmentId
+                .filterNotNull()
+                .onEach {
+                    abacusStateManager.environment?.let {
+                        configureCartera(it)
+                    } ?: run {
+                        logger.e(TAG, "Environment is null")
+                    }
+                }
+                .launchIn(scope)
         }
     }
 

--- a/v4/integration/dydxCartera/src/main/java/exchange/dydx/dydxCartera/v4/DydxV4WalletSetup.kt
+++ b/v4/integration/dydxCartera/src/main/java/exchange/dydx/dydxCartera/v4/DydxV4WalletSetup.kt
@@ -47,7 +47,7 @@ class DydxV4WalletSetup @Inject constructor(
                 val map = json.jsonObject.toMap()
                 val mnemonic = parser.asString(map["mnemonic"])
                 val cosmosAddress = parser.asString(map["address"])
-                if (mnemonic != null && address != null) {
+                if (mnemonic != null) {
                     _status.value = Status.Signed(
                         SetupResult(
                             ethereumAddress = address,


### PR DESCRIPTION
On release build, abacusStateManager.environment might not be yet set when the worker starts.

There is still an issue where the first attempt triggers a WalletConnect NoRelayConnection error.  We will need to look into that in next couple of weeks.