### PR TITLE
MOB-549 Use compile time config for Cartera

### DIFF
--- a/v4/core/src/main/java/exchange/dydx/trading/core/CarteraSetup.kt
+++ b/v4/core/src/main/java/exchange/dydx/trading/core/CarteraSetup.kt
@@ -1,5 +1,6 @@
 package exchange.dydx.trading.core
 
+import android.content.Context
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.FragmentActivity
 import exchange.dydx.cartera.CarteraConfig
@@ -7,6 +8,8 @@ import exchange.dydx.cartera.WalletConnectV2Config
 import exchange.dydx.cartera.WalletProvidersConfig
 import exchange.dydx.cartera.WalletSegueConfig
 import exchange.dydx.utilities.utils.Logging
+import exchange.dydx.trading.common.R
+import exchange.dydx.trading.core.WalletProvidersConfigUtil.getWalletProvidersConfig
 
 object CarteraSetup {
 
@@ -30,11 +33,7 @@ object CarteraSetup {
         }
 
         CarteraConfig.shared = CarteraConfig(
-            walletProvidersConfig = WalletProvidersConfig(
-                null,
-                null,
-                null,
-            ),
+            walletProvidersConfig = getWalletProvidersConfig(activity.applicationContext),
             application = activity.application,
             launcher = launcher,
         )
@@ -47,23 +46,24 @@ object CarteraSetup {
 }
 
 object WalletProvidersConfigUtil {
-    fun getWalletProvidersConfig(): WalletProvidersConfig {
+    fun getWalletProvidersConfig(appContext: Context): WalletProvidersConfig {
+        val appHostUrl = "https://" +  appContext.getString(R.string.app_web_host)
         val walletConnectV2Config = WalletConnectV2Config(
-            "47559b2ec96c09aed9ff2cb54a31ab0e",
-            "dYdX v4",
-            "dYdX Trading App",
-            "https://v4.testnet.dydx.exchange/",
-            listOf<String>("https://v4.testnet.dydx.exchange/logos/dydx-x.png"),
+            projectId = appContext.getString(R.string.wallet_connect_project_id),
+            clientName = appContext.getString(R.string.app_name),
+            clientDescription = appContext.getString(R.string.wallet_connect_description),
+            clientUrl = appHostUrl,
+            iconUrls = listOf<String>(appHostUrl + appContext.getString(R.string.wallet_connect_logo))
         )
 
         val walletSegueConfig = WalletSegueConfig(
-            "https://v4.testnet.dydx.exchange/walletsegue",
+            callbackUrl = appHostUrl + appContext.getString(R.string.wallet_segue_callback)
         )
 
         return WalletProvidersConfig(
-            null,
-            walletConnectV2Config,
-            walletSegueConfig,
+            walletConnectV1 = null,
+            walletConnectV2 = walletConnectV2Config,
+            walletSegue = walletSegueConfig,
         )
     }
 }

--- a/v4/core/src/main/java/exchange/dydx/trading/core/CarteraSetup.kt
+++ b/v4/core/src/main/java/exchange/dydx/trading/core/CarteraSetup.kt
@@ -7,9 +7,9 @@ import exchange.dydx.cartera.CarteraConfig
 import exchange.dydx.cartera.WalletConnectV2Config
 import exchange.dydx.cartera.WalletProvidersConfig
 import exchange.dydx.cartera.WalletSegueConfig
-import exchange.dydx.utilities.utils.Logging
 import exchange.dydx.trading.common.R
 import exchange.dydx.trading.core.WalletProvidersConfigUtil.getWalletProvidersConfig
+import exchange.dydx.utilities.utils.Logging
 
 object CarteraSetup {
 
@@ -47,17 +47,17 @@ object CarteraSetup {
 
 object WalletProvidersConfigUtil {
     fun getWalletProvidersConfig(appContext: Context): WalletProvidersConfig {
-        val appHostUrl = "https://" +  appContext.getString(R.string.app_web_host)
+        val appHostUrl = "https://" + appContext.getString(R.string.app_web_host)
         val walletConnectV2Config = WalletConnectV2Config(
             projectId = appContext.getString(R.string.wallet_connect_project_id),
             clientName = appContext.getString(R.string.app_name),
             clientDescription = appContext.getString(R.string.wallet_connect_description),
             clientUrl = appHostUrl,
-            iconUrls = listOf<String>(appHostUrl + appContext.getString(R.string.wallet_connect_logo))
+            iconUrls = listOf<String>(appHostUrl + appContext.getString(R.string.wallet_connect_logo)),
         )
 
         val walletSegueConfig = WalletSegueConfig(
-            callbackUrl = appHostUrl + appContext.getString(R.string.wallet_segue_callback)
+            callbackUrl = appHostUrl + appContext.getString(R.string.wallet_segue_callback),
         )
 
         return WalletProvidersConfig(

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/DydxGlobalWorkers.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/DydxGlobalWorkers.kt
@@ -44,7 +44,7 @@ class DydxGlobalWorkers(
         DydxAlertsWorker(scope, abacusStateManager, localizer, router, toaster, preferencesStore),
         DydxApiStatusWorker(scope, abacusStateManager, localizer, toaster),
         DydxRestrictionsWorker(scope, abacusStateManager, localizer, toaster),
-        DydxCarteraConfigWorker(scope, abacusStateManager, cachedFileLoader, context, logger),
+        DydxCarteraConfigWorker(abacusStateManager, cachedFileLoader, context, logger),
         DydxTransferSubaccountWorker(scope, abacusStateManager, cosmosClient, formatter, parser, tracker, logger),
         DydxUserTrackingWorker(scope, abacusStateManager, localizer, tracker),
         DydxGasTokenWorker(preferencesStore, abacusStateManager, logger),

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
@@ -1,19 +1,11 @@
 package exchange.dydx.trading.feature.workers.globalworkers
 
-import exchange.dydx.abacus.state.manager.V4Environment
 import exchange.dydx.cartera.CarteraConfig
-import exchange.dydx.cartera.WalletConnectV2Config
-import exchange.dydx.cartera.WalletProvidersConfig
-import exchange.dydx.cartera.WalletSegueConfig
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.trading.common.BuildConfig
 import exchange.dydx.utilities.utils.CachedFileLoader
 import exchange.dydx.utilities.utils.Logging
 import exchange.dydx.utilities.utils.WorkerProtocol
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 private const val TAG = "DydxCarteraConfigWorker"
 
@@ -47,4 +39,3 @@ class DydxCarteraConfigWorker(
         }
     }
 }
-

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.onEach
 private const val TAG = "DydxCarteraConfigWorker"
 
 class DydxCarteraConfigWorker(
-    private val scope: CoroutineScope,
     private val abacusStateManager: AbacusStateManagerProtocol,
     private val cachedFileLoader: CachedFileLoader,
     private val context: android.content.Context,
@@ -39,17 +38,6 @@ class DydxCarteraConfigWorker(
                     logger.e(TAG, "Failed to load wallets.json")
                 }
             }
-
-            abacusStateManager.currentEnvironmentId
-                .filterNotNull()
-                .onEach {
-                    abacusStateManager.environment?.let {
-                        configureCartera(it)
-                    } ?: run {
-                        logger.e(TAG, "Environment is null")
-                    }
-                }
-                .launchIn(scope)
         }
     }
 
@@ -58,42 +46,5 @@ class DydxCarteraConfigWorker(
             isStarted = false
         }
     }
-
-    private fun configureCartera(environment: V4Environment) {
-        val walletProviderConfig = WalletProvidersConfig(
-            walletConnectV1 = null,
-            walletConnectV2 = environment.walletConnectV2Config(abacusStateManager),
-            walletSegue = environment.walletSegueConfig(),
-        )
-
-        CarteraConfig.shared?.updateConfig(
-            walletProviderConfig,
-        )
-    }
 }
 
-private fun V4Environment.walletConnectV2Config(
-    abacusStateManager: AbacusStateManagerProtocol,
-): WalletConnectV2Config? {
-    val projectId = walletConnection?.walletConnect?.v2?.projectId ?: return null
-    val clientName = walletConnection?.walletConnect?.client?.name ?: return null
-    val clientDescription = walletConnection?.walletConnect?.client?.description ?: return null
-    val deploymentUri = abacusStateManager.deploymentUri
-    val iconUrls = listOf(walletConnection?.walletConnect?.client?.iconUrl).filterNotNull()
-
-    return WalletConnectV2Config(
-        projectId = projectId,
-        clientName = clientName,
-        clientDescription = clientDescription,
-        clientUrl = deploymentUri,
-        iconUrls = iconUrls,
-    )
-}
-
-private fun V4Environment.walletSegueConfig(): WalletSegueConfig? {
-    val callbackUrl = walletConnection?.walletSegue?.callbackUrl ?: return null
-
-    return WalletSegueConfig(
-        callbackUrl = callbackUrl,
-    )
-}


### PR DESCRIPTION
WalletConnect configuration needs to be supplied as soon as the main Activity is created.  Otherwise, the behavior becomes unpredictable.  This means we can't fetch the WalletConnect configuration from env.json since the fetch operation would be asynchronous. 

With this PR, the WalletConnect configuration will be supplied at compile time from the strings file like other secrets.  The file is supplied by CD/CI.  For local build, please download and extract the secrets.zip from 1password account (see the Readme instructions).