### PR TITLE
Fix a number of SL/TP issues

### DIFF
--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/streams/TriggerOrderStream.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/streams/TriggerOrderStream.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
@@ -67,7 +66,7 @@ class TriggerOrderStream @Inject constructor(
             marketIdFlow.flatMapLatest { abacusStateManager.state.takeProfitOrders(it, includeLimitOrders) },
             marketIdFlow.flatMapLatest { abacusStateManager.state.stopLossOrders(it, includeLimitOrders) },
         ) { takeProfitOrders, stopLossOrders ->
-            takeProfitOrders.isNullOrEmpty () && stopLossOrders.isNullOrEmpty()
+            takeProfitOrders.isNullOrEmpty() && stopLossOrders.isNullOrEmpty()
         }
             .distinctUntilChanged()
 

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/streams/TriggerOrderStream.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/streams/TriggerOrderStream.kt
@@ -64,10 +64,10 @@ class TriggerOrderStream @Inject constructor(
 
     override val isNewTriggerOrder: Flow<Boolean> =
         combine(
-            marketIdFlow.flatMapLatest { abacusStateManager.state.takeProfitOrders(it, includeLimitOrders).filterNotNull() },
-            marketIdFlow.flatMapLatest { abacusStateManager.state.stopLossOrders(it, includeLimitOrders).filterNotNull() },
+            marketIdFlow.flatMapLatest { abacusStateManager.state.takeProfitOrders(it, includeLimitOrders) },
+            marketIdFlow.flatMapLatest { abacusStateManager.state.stopLossOrders(it, includeLimitOrders) },
         ) { takeProfitOrders, stopLossOrders ->
-            takeProfitOrders.isEmpty() && stopLossOrders.isEmpty()
+            takeProfitOrders.isNullOrEmpty () && stopLossOrders.isNullOrEmpty()
         }
             .distinctUntilChanged()
 

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/trigger/components/DydxTriggerOrderCtaButtonViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/trigger/components/DydxTriggerOrderCtaButtonViewModel.kt
@@ -11,6 +11,7 @@ import exchange.dydx.trading.common.DydxViewModel
 import exchange.dydx.trading.common.navigation.DydxRouter
 import exchange.dydx.trading.feature.trade.streams.MutableTriggerOrderStreaming
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import javax.inject.Inject
@@ -23,13 +24,16 @@ class DydxTriggerOrderCtaButtonViewModel @Inject constructor(
     private val router: DydxRouter,
 ) : ViewModel(), DydxViewModel {
 
+    private val pendingSubmissionFlow: MutableStateFlow<Int> = MutableStateFlow(0)
+
     val state: Flow<DydxTriggerOrderCtaButtonView.ViewState?> =
         combine(
             triggerOrderStream.isNewTriggerOrder,
             abacusStateManager.state.triggerOrdersInput,
             abacusStateManager.state.validationErrors,
-        ) { isNewTriggerOrder, triggerOrdersInput, errors ->
-            createViewState(isNewTriggerOrder, triggerOrdersInput, errors)
+            pendingSubmissionFlow,
+        ) { isNewTriggerOrder, triggerOrdersInput, error, pendingSubmission ->
+            createViewState(isNewTriggerOrder, triggerOrdersInput, error, pendingSubmission)
         }
             .distinctUntilChanged()
 
@@ -37,22 +41,30 @@ class DydxTriggerOrderCtaButtonViewModel @Inject constructor(
         isNewTriggerOrder: Boolean,
         triggerOrdersInput: TriggerOrdersInput?,
         errors: List<ValidationError>,
+        pendingSubmission: Int,
     ): DydxTriggerOrderCtaButtonView.ViewState {
+        val isSubmitting = pendingSubmission > 0
         val firstBlockingError =
             errors.firstOrNull { it.type == ErrorType.required || it.type == ErrorType.error }
-        val buttonTitle = firstBlockingError?.resources?.action?.localized
-            ?: if (isNewTriggerOrder) {
-                localizer.localize("APP.TRADE.ADD_TRIGGERS")
-            } else {
-                localizer.localize("APP.TRADE.UPDATE_TRIGGERS")
-            }
+        val buttonTitle = if (isSubmitting) {
+            localizer.localize("APP.TRADE.SUBMITTING_ORDER")
+        } else {
+            firstBlockingError?.resources?.action?.localized
+                ?: if (isNewTriggerOrder) {
+                    localizer.localize("APP.TRADE.ADD_TRIGGERS")
+                } else {
+                    localizer.localize("APP.TRADE.UPDATE_TRIGGERS")
+                }
+        }
         val inputSize = triggerOrdersInput?.size ?: 0.0
         val tpSize = triggerOrdersInput?.takeProfitOrder?.size ?: 0.0
         val slSize = triggerOrdersInput?.stopLossOrder?.size ?: 0.0
         val hasSize = inputSize != 0.0 || tpSize != 0.0 || slSize != 0.0
-0        return DydxTriggerOrderCtaButtonView.ViewState(
+        return DydxTriggerOrderCtaButtonView.ViewState(
             localizer = localizer,
-            ctaButtonState = if (
+            ctaButtonState = if (isSubmitting) {
+                DydxTriggerOrderCtaButtonView.State.Disabled(buttonTitle)
+            } else if (
                 (
                     triggerOrdersInput?.takeProfitOrder?.price?.triggerPrice != null || triggerOrdersInput?.takeProfitOrder?.orderId != null ||
                         triggerOrdersInput?.stopLossOrder?.price?.triggerPrice != null || triggerOrdersInput?.stopLossOrder?.orderId != null
@@ -65,10 +77,12 @@ class DydxTriggerOrderCtaButtonViewModel @Inject constructor(
                 DydxTriggerOrderCtaButtonView.State.Disabled(buttonTitle)
             },
             ctaAction = {
-                router.navigateBack()
-                abacusStateManager.commitTriggerOrders { status ->
-                    print("Trigger orders committed with status: $status")
+                pendingSubmissionFlow.value = abacusStateManager.commitTriggerOrders { _ ->
                     // order status will be shown from PresentationProtocol.showToast()
+                    pendingSubmissionFlow.value -= 1
+                    if (pendingSubmissionFlow.value == 0) {
+                        router.navigateBack()
+                    }
                 }
             },
         )

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/trigger/components/DydxTriggerOrderCtaButtonViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/trigger/components/DydxTriggerOrderCtaButtonViewModel.kt
@@ -28,8 +28,8 @@ class DydxTriggerOrderCtaButtonViewModel @Inject constructor(
             triggerOrderStream.isNewTriggerOrder,
             abacusStateManager.state.triggerOrdersInput,
             abacusStateManager.state.validationErrors,
-        ) { isNewTriggerOrder, triggerOrdersInput, error ->
-            createViewState(isNewTriggerOrder, triggerOrdersInput, error)
+        ) { isNewTriggerOrder, triggerOrdersInput, errors ->
+            createViewState(isNewTriggerOrder, triggerOrdersInput, errors)
         }
             .distinctUntilChanged()
 

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/trigger/components/DydxTriggerOrderCtaButtonViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/trigger/components/DydxTriggerOrderCtaButtonViewModel.kt
@@ -50,7 +50,7 @@ class DydxTriggerOrderCtaButtonViewModel @Inject constructor(
         val tpSize = triggerOrdersInput?.takeProfitOrder?.size ?: 0.0
         val slSize = triggerOrdersInput?.stopLossOrder?.size ?: 0.0
         val hasSize = inputSize != 0.0 || tpSize != 0.0 || slSize != 0.0
-        return DydxTriggerOrderCtaButtonView.ViewState(
+0        return DydxTriggerOrderCtaButtonView.ViewState(
             localizer = localizer,
             ctaButtonState = if (
                 (
@@ -66,7 +66,8 @@ class DydxTriggerOrderCtaButtonViewModel @Inject constructor(
             },
             ctaAction = {
                 router.navigateBack()
-                abacusStateManager.commitTriggerOrders { _ ->
+                abacusStateManager.commitTriggerOrders { status ->
+                    print("Trigger orders committed with status: $status")
                     // order status will be shown from PresentationProtocol.showToast()
                 }
             },

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
@@ -118,7 +118,7 @@ interface AbacusStateManagerProtocol {
     fun commitCCTPWithdraw(callback: (Boolean, ParsingError?, Any?) -> Unit)
 
     fun triggerOrders(input: String?, type: TriggerOrdersInputField?)
-    fun commitTriggerOrders(callback: (SubmissionStatus) -> Unit)
+    fun commitTriggerOrders(callback: (SubmissionStatus) -> Unit): Int
 
     fun adjustIsolatedMargin(data: String?, type: AdjustIsolatedMarginInputField?)
     fun commitAdjustIsolatedMargin(statusCallback: (SubmissionStatus) -> Unit)
@@ -434,14 +434,15 @@ class AbacusStateManager @Inject constructor(
         asyncStateManager.triggerOrders(input, type)
     }
 
-    override fun commitTriggerOrders(callback: (AbacusStateManagerProtocol.SubmissionStatus) -> Unit) {
-        asyncStateManager.commitTriggerOrders { successful: Boolean, error: ParsingError?, _ ->
+    override fun commitTriggerOrders(callback: (AbacusStateManagerProtocol.SubmissionStatus) -> Unit): Int {
+        val payload = asyncStateManager.commitTriggerOrders { successful: Boolean, error: ParsingError?, _ ->
             if (successful) {
                 callback(AbacusStateManagerProtocol.SubmissionStatus.Success)
             } else {
                 callback(AbacusStateManagerProtocol.SubmissionStatus.Failed(error))
             }
         }
+        return (payload?.cancelOrderPayloads?.size ?: 0) + (payload?.placeOrderPayloads?.size ?: 0)
     }
 
     override fun adjustIsolatedMargin(data: String?, type: AdjustIsolatedMarginInputField?) {

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
@@ -118,7 +118,7 @@ interface AbacusStateManagerProtocol {
     fun commitCCTPWithdraw(callback: (Boolean, ParsingError?, Any?) -> Unit)
 
     fun triggerOrders(input: String?, type: TriggerOrdersInputField?)
-    fun commitTriggerOrders(callback: (SubmissionStatus) -> Unit): Int
+    fun commitTriggerOrders(callback: (SubmissionStatus) -> Unit)
 
     fun adjustIsolatedMargin(data: String?, type: AdjustIsolatedMarginInputField?)
     fun commitAdjustIsolatedMargin(statusCallback: (SubmissionStatus) -> Unit)
@@ -434,15 +434,14 @@ class AbacusStateManager @Inject constructor(
         asyncStateManager.triggerOrders(input, type)
     }
 
-    override fun commitTriggerOrders(callback: (AbacusStateManagerProtocol.SubmissionStatus) -> Unit): Int {
-        val payload = asyncStateManager.commitTriggerOrders { successful: Boolean, error: ParsingError?, _ ->
+    override fun commitTriggerOrders(callback: (AbacusStateManagerProtocol.SubmissionStatus) -> Unit) {
+        asyncStateManager.commitTriggerOrders { successful: Boolean, error: ParsingError?, _ ->
             if (successful) {
                 callback(AbacusStateManagerProtocol.SubmissionStatus.Success)
             } else {
                 callback(AbacusStateManagerProtocol.SubmissionStatus.Failed(error))
             }
         }
-        return (payload?.cancelOrderPayloads?.size ?: 0) + (payload?.placeOrderPayloads?.size ?: 0)
     }
 
     override fun adjustIsolatedMargin(data: String?, type: AdjustIsolatedMarginInputField?) {


### PR DESCRIPTION
Delaying router action until after the submission. Otherwise, the clean-up logic would mutable the submission data in Abacus.
Updating isNewTriggerOrder so that it always emits. 
[untitled.webm](https://github.com/dydxprotocol/v4-native-android/assets/102453770/eb55809e-8382-4868-8d7f-5030db462bcb)

