### PR TITLE
Fix leverage slider crash

### DIFF
--- a/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/views/GradientSlider.kt
+++ b/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/views/GradientSlider.kt
@@ -29,7 +29,7 @@ fun Preview_GradientSlider() {
 object GradientSlider {
     data class ViewState(
         val localizer: LocalizerProtocol,
-        val leftRatio: Float = -1.0f,
+        val leftRatio: Float = -0.5f,
         val rightRatio: Float = 1.0f,
         val value: Float = 0.0f,
         val valueRange: ClosedFloatingPointRange<Float>,
@@ -64,13 +64,13 @@ object GradientSlider {
             )
         } else if (state.leftRatio <= 0 && state.rightRatio <= 0) {
             brush = Brush.linearGradient(
-                0.0f to GradientType.MINUS.color.color.copy(alpha = abs(left)),
-                1.0f to GradientType.MINUS.color.color.copy(alpha = abs(right)),
+                0.0f to GradientType.MINUS.color.color.copy(alpha = left),
+                1.0f to GradientType.MINUS.color.color.copy(alpha = right),
             )
         } else {
             brush = Brush.linearGradient(
-                0.0f to GradientType.PLUS.color.color.copy(alpha = abs(left)),
-                1.0f to GradientType.PLUS.color.color.copy(alpha = abs(right)),
+                0.0f to GradientType.PLUS.color.color.copy(alpha = left),
+                1.0f to GradientType.PLUS.color.color.copy(alpha = right),
             )
         }
 

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageView.kt
@@ -43,6 +43,8 @@ import exchange.dydx.trading.feature.shared.views.GradientSlider
 import exchange.dydx.trading.feature.shared.views.SideTextView
 import exchange.dydx.utilities.utils.rounded
 import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
 
 @Preview
 @Composable
@@ -209,7 +211,8 @@ object DydxTradeInputLeverageView : DydxComponent {
             return
         }
 
-        val positionRatio = (positionLeverage / maxLeverage).rounded(toPlaces = 1)
+        val value = (positionLeverage / maxLeverage).rounded(toPlaces = 1)
+        val positionRatio = min(1f, max(-1f, value))
 
         val sliderViewState = GradientSlider.ViewState(
             localizer = state.localizer,

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
@@ -6,19 +6,24 @@ import exchange.dydx.abacus.output.input.OrderSide
 import exchange.dydx.abacus.output.input.TradeInput
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.state.model.TradeInputField
+import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.trading.common.DydxViewModel
 import exchange.dydx.trading.common.formatter.DydxFormatter
+import exchange.dydx.utilities.utils.Logging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import javax.inject.Inject
+
+private val TAG = "DydxTradeInputLeverageViewModel"
 
 @HiltViewModel
 class DydxTradeInputLeverageViewModel @Inject constructor(
     private val localizer: LocalizerProtocol,
     private val abacusStateManager: AbacusStateManagerProtocol,
     private val formatter: DydxFormatter,
+    private val logger: Logging,
 ) : ViewModel(), DydxViewModel {
 
     val state: Flow<DydxTradeInputLeverageView.ViewState?> =
@@ -36,6 +41,9 @@ class DydxTradeInputLeverageViewModel @Inject constructor(
         tradeInput: TradeInput?,
         positionLeverage: Double?
     ): DydxTradeInputLeverageView.ViewState {
+        if ((positionLeverage ?: 0.0) > tradeInput?.options?.maxLeverage ?: 0.0) {
+            logger.e(TAG, "Position leverage is greater than max leverage")
+        }
         return DydxTradeInputLeverageView.ViewState(
             localizer = localizer,
             formatter = formatter,

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
@@ -6,7 +6,6 @@ import exchange.dydx.abacus.output.input.OrderSide
 import exchange.dydx.abacus.output.input.TradeInput
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.state.model.TradeInputField
-import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.trading.common.DydxViewModel
 import exchange.dydx.trading.common.formatter.DydxFormatter


### PR DESCRIPTION
[Link](https://console.firebase.google.com/project/dydx-operations-services/crashlytics/app/android:trade.opsdao.dydxchain/issues/71e45799fdf47e20b09b3f75f22e5b2f?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_ISSUE&time=last-twenty-four-hours&types=crash&sessionEventKey=6675407703C500016B460A9FACC37889_1961323697509674506) 
[Link](https://console.firebase.google.com/project/dydx-operations-services/crashlytics/app/android:trade.opsdao.dydxchain/issues/acd1906d57223df3dba5b9878b9820f3?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_ISSUE&time=last-twenty-four-hours&types=crash&sessionEventKey=6675A27F00B2000138520A9FACC37889_1961435246006293930)

Can't reproduce but it looks like positionLeverage becomes greater than maxLeverage from Abacus.  