### PR TITLE
MOB-574 MOB-576 Fix issues with Adjust Leverage screen

### DIFF
--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/margin/components/percent/DydxAdjustMarginInputPercentView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/margin/components/percent/DydxAdjustMarginInputPercentView.kt
@@ -1,12 +1,14 @@
 package exchange.dydx.trading.feature.trade.margin.components.percent
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.platformui.components.buttons.PlatformSelectionButton
@@ -72,11 +74,11 @@ object DydxAdjustMarginInputPercentView : DydxComponent {
 
         PlatformTabGroup(
             modifier = modifier.fillMaxWidth(),
-            scrollingEnabled = true,
             items = state.percentageOptions.map {
                 { modifier ->
                     PlatformSelectionButton(
-                        modifier = modifier,
+                        modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp)
+                            .fillMaxWidth(),
                         selected = false,
                     ) {
                         Text(
@@ -93,7 +95,8 @@ object DydxAdjustMarginInputPercentView : DydxComponent {
             selectedItems = state.percentageOptions.map {
                 { modifier ->
                     PlatformSelectionButton(
-                        modifier = modifier,
+                        modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp)
+                            .fillMaxWidth(),
                         selected = true,
                     ) {
                         Text(
@@ -107,7 +110,7 @@ object DydxAdjustMarginInputPercentView : DydxComponent {
                     }
                 }
             },
-            equalWeight = false,
+            equalWeight = true,
             currentSelection = state.percentageOptions.indexOfFirst {
                 it.percentage == state.percentage
             },

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageView.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import exchange.dydx.abacus.protocols.LocalizerProtocol
+import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.utils.Parser
 import exchange.dydx.platformui.components.buttons.PlatformButton
 import exchange.dydx.platformui.components.buttons.PlatformButtonState
 import exchange.dydx.platformui.components.buttons.PlatformSelectionButton
@@ -54,6 +56,7 @@ fun Preview_DydxTradeInputTargetLeverageView() {
 object DydxTradeInputTargetLeverageView : DydxComponent {
     data class ViewState(
         val localizer: LocalizerProtocol,
+        val parser: ParserProtocol,
         val leverageText: String?,
         val leverageOptions: List<LeverageTextAndValue>?,
         val logoUrl: String? = null,
@@ -64,6 +67,7 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
         companion object {
             val preview = ViewState(
                 localizer = MockLocalizer(),
+                parser = Parser(),
                 leverageText = "1.0",
                 leverageOptions = listOf(
                     LeverageTextAndValue("1.0", "1.0"),
@@ -264,7 +268,8 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                 } ?: listOf(),
                 equalWeight = false,
                 currentSelection = state?.leverageOptions?.indexOfFirst {
-                    it.value.toDouble() == state.leverageText?.toDouble()
+                    val leverageTextValue = state.parser.asDouble(state.leverageText)
+                    it.value.toDouble() == leverageTextValue
                 },
                 onSelectionChanged = { it ->
                     state?.leverageOptions?.get(it)?.value?.let { value ->

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageView.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -219,6 +220,8 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
         modifier: Modifier,
         state: ViewState?
     ) {
+        val focusManager = LocalFocusManager.current
+
         Row(
             modifier = modifier
                 .padding(
@@ -230,11 +233,11 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
         ) {
             PlatformTabGroup(
                 modifier = Modifier.fillMaxWidth(),
-                scrollingEnabled = true,
                 items = state?.leverageOptions?.map {
                     { modifier ->
                         PlatformSelectionButton(
-                            modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp),
+                            modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp)
+                                .fillMaxWidth(),
                             selected = false,
                         ) {
                             Text(
@@ -252,7 +255,8 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                     { modifier ->
 
                         PlatformSelectionButton(
-                            modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp),
+                            modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp)
+                                .fillMaxWidth(),
                             selected = true,
                         ) {
                             Text(
@@ -266,7 +270,7 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                         }
                     }
                 } ?: listOf(),
-                equalWeight = false,
+                equalWeight = true,
                 currentSelection = state?.leverageOptions?.indexOfFirst {
                     val leverageTextValue = state.parser.asDouble(state.leverageText)
                     it.value.toDouble() == leverageTextValue
@@ -274,6 +278,8 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                 onSelectionChanged = { it ->
                     state?.leverageOptions?.get(it)?.value?.let { value ->
                         state.selectAction?.invoke(value)
+
+                        focusManager.clearFocus()
                     }
                 },
             )

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageViewModel.kt
@@ -5,6 +5,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import exchange.dydx.abacus.output.Asset
 import exchange.dydx.abacus.output.input.TradeInput
 import exchange.dydx.abacus.protocols.LocalizerProtocol
+import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.state.model.TradeInputField
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.trading.common.DydxViewModel
@@ -28,6 +29,7 @@ import kotlin.time.Duration.Companion.seconds
 @HiltViewModel
 class DydxTradeInputTargetLeverageViewModel @Inject constructor(
     private val localizer: LocalizerProtocol,
+    private val parser: ParserProtocol,
     private val router: DydxRouter,
     private val abacusStateManager: AbacusStateManagerProtocol,
     private val formatter: DydxFormatter,
@@ -67,11 +69,12 @@ class DydxTradeInputTargetLeverageViewModel @Inject constructor(
         val leverages = leverageOptions(maxLeverage)
         return DydxTradeInputTargetLeverageView.ViewState(
             localizer = localizer,
+            parser = parser,
             leverageText = targetLeverage ?: formatter.raw(tradeInput?.targetLeverage, 2),
             leverageOptions = leverages,
             logoUrl = assetMap[assetId]?.resources?.imageUrl,
             selectAction = { leverage ->
-                this.targetLeverage.value = leverage
+                this.targetLeverage.value =  leverage
             },
             closeAction = {
                 closeView()

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageViewModel.kt
@@ -74,7 +74,7 @@ class DydxTradeInputTargetLeverageViewModel @Inject constructor(
             leverageOptions = leverages,
             logoUrl = assetMap[assetId]?.resources?.imageUrl,
             selectAction = { leverage ->
-                this.targetLeverage.value =  leverage
+                this.targetLeverage.value = leverage
             },
             closeAction = {
                 closeView()


### PR DESCRIPTION
Bugs: 

- ISO Bug - Android: crashing when inputing target leverage as text
- ISO Bug - Android Adjusting Target Leverage: Options do not fill width

![Screenshot_1719263070](https://github.com/dydxprotocol/v4-native-android/assets/102453770/86faaf3b-1a84-40bb-b2fd-3bd92549ad1e)
