### PR TITLE
Compute maxLeverage based on market config rather than trade input.

### DIFF
--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageView.kt
@@ -73,8 +73,10 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                 leverageOptions = listOf(
                     LeverageTextAndValue("1.0", "1.0"),
                     LeverageTextAndValue("2.0", "2.0"),
+                    LeverageTextAndValue("2.0", "2.0"),
                     LeverageTextAndValue("5.0", "5.0"),
                     LeverageTextAndValue("10.0", "10.0"),
+                    LeverageTextAndValue("max", "10.0"),
                 ),
             )
         }

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
@@ -7,12 +7,16 @@ import exchange.dydx.abacus.output.input.TradeInput
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.state.model.TradeInputField
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
+import exchange.dydx.dydxstatemanager.maxLeverage
 import exchange.dydx.trading.common.DydxViewModel
 import exchange.dydx.trading.common.formatter.DydxFormatter
 import exchange.dydx.utilities.utils.Logging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
 
 private val TAG = "DydxTradeInputLeverageViewModel"
@@ -28,19 +32,21 @@ class DydxTradeInputLeverageViewModel @Inject constructor(
     val state: Flow<DydxTradeInputLeverageView.ViewState?> =
         combine(
             abacusStateManager.state.tradeInput,
+            abacusStateManager.state.tradeInput.mapNotNull { it?.marketId }.flatMapLatest { abacusStateManager.state.market(it) }.map { it.maxLeverage },
             abacusStateManager.state.selectedSubaccountPositions,
-        ) { tradeInput, positions ->
+        ) { tradeInput, maxLeverage, positions ->
             val marketId = tradeInput?.marketId ?: return@combine null
             val position = positions?.firstOrNull { it.id == marketId }
-            createViewState(tradeInput, position?.leverage?.current)
+            createViewState(tradeInput, maxLeverage, position?.leverage?.current)
         }
             .distinctUntilChanged()
 
     private fun createViewState(
         tradeInput: TradeInput?,
+        maxLeverage: Double,
         positionLeverage: Double?
     ): DydxTradeInputLeverageView.ViewState {
-        if ((positionLeverage ?: 0.0) > tradeInput?.options?.maxLeverage ?: 0.0) {
+        if ((positionLeverage ?: 0.0) > maxLeverage) {
             logger.e(TAG, "Position leverage is greater than max leverage")
         }
         return DydxTradeInputLeverageView.ViewState(
@@ -48,7 +54,7 @@ class DydxTradeInputLeverageViewModel @Inject constructor(
             formatter = formatter,
             leverage = tradeInput?.size?.leverage ?: 0.0,
             positionLeverage = positionLeverage,
-            maxLeverage = tradeInput?.options?.maxLeverage,
+            maxLeverage = maxLeverage,
             side = when (tradeInput?.side) {
                 OrderSide.Buy -> DydxTradeInputLeverageView.OrderSide.Buy
                 OrderSide.Sell -> DydxTradeInputLeverageView.OrderSide.Sell

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/MarketExtensions.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/MarketExtensions.kt
@@ -1,0 +1,10 @@
+package exchange.dydx.dydxstatemanager
+
+import exchange.dydx.abacus.output.PerpetualMarket
+
+val PerpetualMarket?.maxLeverage: Double
+    get() {
+        if (this == null) return 5.0
+        val imf = configs?.run { effectiveInitialMarginFraction ?: initialMarginFraction }
+        return imf?.let { 1.0 / it } ?: 5.0
+    }

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/MarketExtensions.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/MarketExtensions.kt
@@ -4,7 +4,7 @@ import exchange.dydx.abacus.output.PerpetualMarket
 
 val PerpetualMarket?.maxLeverage: Double
     get() {
-        if (this == null) return 5.0
-        val imf = configs?.run { effectiveInitialMarginFraction ?: initialMarginFraction }
-        return imf?.let { 1.0 / it } ?: 5.0
+        val imf = this?.configs?.run { effectiveInitialMarginFraction ?: initialMarginFraction }
+            .takeIf { it != 0.0 }
+        return imf?.let { 1.0 / it } ?: 1.0
     }


### PR DESCRIPTION
this matches what both ios and web do.

![Screenshot 2024-06-27 at 4 44 14 PM](https://github.com/dydxprotocol/v4-native-android/assets/163016611/730b81d8-9282-417d-b9d1-72720e75dac0)
