### PR TITLE
Fix leverage slider flickering.

### DIFF
--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.trading.feature.trade.tradeinput.components.inputfields.leverage
 
 import androidx.lifecycle.ViewModel
+import com.hoc081098.flowext.flatMapFirst
 import dagger.hilt.android.lifecycle.HiltViewModel
 import exchange.dydx.abacus.output.input.OrderSide
 import exchange.dydx.abacus.output.input.TradeInput
@@ -14,9 +15,8 @@ import exchange.dydx.utilities.utils.Logging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
 
 private val TAG = "DydxTradeInputLeverageViewModel"
@@ -32,7 +32,11 @@ class DydxTradeInputLeverageViewModel @Inject constructor(
     val state: Flow<DydxTradeInputLeverageView.ViewState?> =
         combine(
             abacusStateManager.state.tradeInput,
-            abacusStateManager.state.tradeInput.mapNotNull { it?.marketId }.flatMapLatest { abacusStateManager.state.market(it) }.map { it.maxLeverage },
+            abacusStateManager.state.tradeInput
+                .map { it?.marketId }
+                .filterNotNull()
+                .flatMapFirst { abacusStateManager.state.market(it) }
+                .map { it.maxLeverage },
             abacusStateManager.state.selectedSubaccountPositions,
         ) { tradeInput, maxLeverage, positions ->
             val marketId = tradeInput?.marketId ?: return@combine null


### PR DESCRIPTION
Max leverage was oscillating between 1.0 (default for null market / market config) and the real maxLeverage.

The issue was due to multiple emissions of `tradeInput` causing a switch to a new flow of `state.market(id)` which always starts with `null` before emitting the real value, leading to `1.0` max leverage.

Our state flows generally should try to start with the correct value instead of null, i'll make a wider change to fix that.