### PR TITLE
Deposit state cleanup/fixes. Transfer state is now properly emitted o…

### DIFF
--- a/v4/app/src/main/java/exchange/dydx/trading/AppModule.kt
+++ b/v4/app/src/main/java/exchange/dydx/trading/AppModule.kt
@@ -77,10 +77,10 @@ interface AppModule {
         ): ThemeSettings {
             var theme = preferenceStore.read(PreferenceKeys.Theme)
             if (theme.isNullOrEmpty()) {
-                theme = "dark"
+                theme = "classic_dark"
             }
             val themeConfigValue =
-                ThemeConfig.createFromPreference(appContext, theme, logger) ?: ThemeConfig.dark(appContext)
+                ThemeConfig.createFromPreference(appContext, theme, logger) ?: ThemeConfig.classicDark(appContext)
             val themeConfig = MutableStateFlow<ThemeConfig?>(themeConfigValue)
             val styleConfig =
                 MutableStateFlow<StyleConfig?>(JsonUtils.loadFromAssets(appContext, "dydxStyle.json"))

--- a/v4/feature/newsalerts/src/main/java/exchange/dydx/trading/feature/newsalerts/alerts/alertprovider/providers/DydxTransferAlertsProvider.kt
+++ b/v4/feature/newsalerts/src/main/java/exchange/dydx/trading/feature/newsalerts/alerts/alertprovider/providers/DydxTransferAlertsProvider.kt
@@ -3,6 +3,7 @@ package exchange.dydx.trading.feature.newsalerts.alerts.alertprovider.providers
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferInstance
+import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferStateManagerProtocol
 import exchange.dydx.dydxstatemanager.localizeWithParams
 import exchange.dydx.dydxstatemanager.nativeTokenName
 import exchange.dydx.dydxstatemanager.usdcTokenName
@@ -22,6 +23,7 @@ import java.util.Date
 import javax.inject.Inject
 
 class DydxTransferAlertsProvider @Inject constructor(
+    transferStateManager: DydxTransferStateManagerProtocol,
     private val abacusStateManger: AbacusStateManagerProtocol,
     private val router: DydxRouter,
     private val localizer: LocalizerProtocol,
@@ -31,7 +33,7 @@ class DydxTransferAlertsProvider @Inject constructor(
     override val alertType: AlertType = AlertType.Transfer
 
     override val items: Flow<List<DydxAlertsProviderItemProtocol>> =
-        abacusStateManger.state.transferState
+        transferStateManager.state
             .map {
                 createAlertItems(it?.transfers) ?: emptyList()
             }

--- a/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/status/DydxTransferStatusView.kt
+++ b/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/status/DydxTransferStatusView.kt
@@ -32,7 +32,7 @@ import exchange.dydx.trading.feature.shared.views.ProgressStepView
 @Composable
 fun Preview_DydxTransferStatusView() {
     DydxThemedPreviewSurface {
-        DydxTransferStatusView.Content(Modifier, DydxTransferStatusView.ViewState.preview)
+        DydxTransferStatusView.Content(Modifier, null)
     }
 }
 

--- a/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/utils/DydxTransferInstanceStore.kt
+++ b/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/utils/DydxTransferInstanceStore.kt
@@ -1,11 +1,10 @@
 package exchange.dydx.trading.feature.transfer.utils
 
-import dagger.hilt.android.scopes.ActivityRetainedScoped
 import exchange.dydx.abacus.output.input.TransferInput
 import exchange.dydx.abacus.output.input.TransferType
 import exchange.dydx.abacus.protocols.ParserProtocol
-import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferInstance
+import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferStateManagerProtocol
 import java.time.Instant
 import javax.inject.Inject
 
@@ -13,9 +12,8 @@ interface DydxTransferInstanceStoring {
     fun addTransferHash(hash: String, fromChainName: String?, toChainName: String?, transferInput: TransferInput)
 }
 
-@ActivityRetainedScoped
 class DydxTransferInstanceStore @Inject constructor(
-    private val abacusStateManager: AbacusStateManagerProtocol,
+    private val transferStateManager: DydxTransferStateManagerProtocol,
     private val parser: ParserProtocol,
 ) : DydxTransferInstanceStoring {
     override fun addTransferHash(
@@ -42,24 +40,24 @@ class DydxTransferInstanceStore @Inject constructor(
             isCctp = transferInput.isCctp,
             requestId = transferInput.requestPayload?.requestId,
         )
-        abacusStateManager.addTransferInstance(transfer)
+        transferStateManager.add(transfer)
     }
 }
 
 val TransferInput.chainName: String?
     get() {
-        if (chain != null) {
-            return resources?.chainResources?.get(chain)?.chainName
+        return if (chain != null) {
+            resources?.chainResources?.get(chain)?.chainName
         } else {
-            return null
+            null
         }
     }
 
 val TransferInput.networkName: String?
     get() {
-        if (chain != null) {
-            return resources?.chainResources?.get(chain)?.networkName
+        return if (chain != null) {
+            resources?.chainResources?.get(chain)?.networkName
         } else {
-            return null
+            null
         }
     }

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusState.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusState.kt
@@ -43,8 +43,6 @@ import exchange.dydx.abacus.responses.ParsingError
 import exchange.dydx.abacus.responses.ParsingErrorType
 import exchange.dydx.abacus.state.manager.ApiState
 import exchange.dydx.abacus.state.manager.SingletonAsyncAbacusStateManagerProtocol
-import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferInstance
-import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferState
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletInstance
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletState
 import exchange.dydx.trading.common.di.CoroutineScopes
@@ -66,7 +64,6 @@ class AbacusState(
     private val lastOrderPublisher: StateFlow<SubaccountOrder?>,
     val alerts: StateFlow<List<Notification>?>,
     val documentation: StateFlow<Documentation?>,
-    val transferState: StateFlow<DydxTransferState?>,
     private val abacusStateManager: SingletonAsyncAbacusStateManagerProtocol,
     private val parser: ParserProtocol,
     @CoroutineScopes.App private val stateManagerScope: CoroutineScope,
@@ -103,12 +100,6 @@ class AbacusState(
                 val subaccountNumber = subaccountNumber ?: return@map null
                 it?.get("$subaccountNumber")?.toList()
             }
-            .stateIn(stateManagerScope, SharingStarted.Lazily, null)
-    }
-
-    fun transferInstance(transactionHash: String?): StateFlow<DydxTransferInstance?> {
-        return transferState
-            .map { it?.transfers?.first { it.transactionHash == transactionHash } }
             .stateIn(stateManagerScope, SharingStarted.Lazily, null)
     }
 

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusStateManager.kt
@@ -39,7 +39,6 @@ import exchange.dydx.abacus.state.v2.supervisor.AppConfigsV2
 import exchange.dydx.abacus.state.v2.supervisor.OnboardingConfigs
 import exchange.dydx.abacus.utils.IList
 import exchange.dydx.abacus.utils.IOImplementations
-import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferInstance
 import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferStateManagerProtocol
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletInstance
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletStateManagerProtocol
@@ -103,8 +102,6 @@ interface AbacusStateManagerProtocol {
     fun closePosition(statusCallback: (SubmissionStatus) -> Unit)
     fun cancelOrder(orderId: String, statusCallback: (SubmissionStatus) -> Unit)
 
-    fun addTransferInstance(transfer: DydxTransferInstance)
-    fun removeTransferInstance(transfer: DydxTransferInstance)
     fun transferStatus(
         hash: String,
         fromChainId: String?,
@@ -218,7 +215,6 @@ class AbacusStateManager @Inject constructor(
         alerts = alertsPublisher,
         documentation = documentationPublisher,
         abacusStateManager = asyncStateManager,
-        transferState = transferStateManager.state,
         parser = parser,
         stateManagerScope = appScope,
     )
@@ -395,14 +391,6 @@ class AbacusStateManager @Inject constructor(
                 statusCallback(AbacusStateManagerProtocol.SubmissionStatus.Failed(error))
             }
         }
-    }
-
-    override fun addTransferInstance(transfer: DydxTransferInstance) {
-        transferStateManager.add(transfer)
-    }
-
-    override fun removeTransferInstance(transfer: DydxTransferInstance) {
-        transferStateManager.remove(transfer)
     }
 
     override fun transferStatus(


### PR DESCRIPTION
…n the StateFlow. Deposits are still a bit broken, but this at least gets to a clearer UX for the user.

This PR includes a couple changes:

- Removes TransferState from AbacusState. This does not come from Abacus, consumers can just inject the TransferStateManagerProtocol directly.
- Fixes DydxTransferStateManager so that state updates are actually emitted on the StateFlow. Also automated writing to the store via a collect { } instead of relying on developers to manually write updates to the store.
- Bunch of cleanup in DydxTransferStatusViewModel: Timer cleanup, accessing transfer state synchronously, router.navigateBack() if transfer is not found

**NOTABLY DEPOSITS ARE STILL BROKEN. I AM STILL INVESTIGATING.**

But, things are better than before. Previously, users would always be stuck on a blank screen with no way to go back. Now, we at least show the screen or navigate back automatically.

<img width="395" alt="Screenshot 2024-07-03 at 10 36 10 PM" src="https://github.com/dydxprotocol/v4-native-android/assets/163016611/da08bd0b-c693-45ba-8877-171a504fe07c">
