### PR TITLE
Optional to disable PlatformAutoSizingText from PlatformButton

### DIFF
--- a/v4/platformUI/src/main/java/exchange/dydx/platformui/components/buttons/PlatformButton.kt
+++ b/v4/platformUI/src/main/java/exchange/dydx/platformui/components/buttons/PlatformButton.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.SnackbarDefaults.backgroundColor
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,6 +58,7 @@ fun PlatformButton(
     state: PlatformButtonState = PlatformButtonState.Primary,
     text: String?,
     fontSize: ThemeFont.FontSize = ThemeFont.FontSize.medium,
+    fitText: Boolean = false,
     leadingContent: @Composable (() -> Unit)? = null,
     trailingContent: @Composable (() -> Unit)? = null,
     action: () -> Unit,
@@ -104,11 +106,19 @@ fun PlatformButton(
                 leadingContent()
             }
             if (text != null) {
-                PlatformAutoSizingText(
-                    textStyle = TextStyle.dydxDefault.themeFont(fontSize = fontSize)
-                        .themeColor(foreground = textColor),
-                    text = text,
-                )
+                if (fitText) {
+                    PlatformAutoSizingText(
+                        textStyle = TextStyle.dydxDefault.themeFont(fontSize = fontSize)
+                            .themeColor(foreground = textColor),
+                        text = text,
+                    )
+                } else {
+                    Text(
+                        text = text,
+                        style = TextStyle.dydxDefault.themeFont(fontSize = fontSize)
+                            .themeColor(foreground = textColor),
+                    )
+                }
             }
             if (trailingContent != null) {
                 trailingContent()


### PR DESCRIPTION
The PlatformAutoSizingText hack doesn't observe the text color, so the primary button text is barely visible.  

I am not sure what the usecase for PlatformAutoSizingText in PlatformButton is, but I am disabling it by default.  We can turn it on for specific usecases.

Before:
![Screenshot_1720214408](https://github.com/dydxprotocol/v4-native-android/assets/102453770/cb29e4c4-b296-48e3-99b7-e4588417c11b)


After:
![Screenshot_1720257374](https://github.com/dydxprotocol/v4-native-android/assets/102453770/fd6648d7-3fcf-4ab4-83a1-48ceccd5dfb4)

