### PR TITLE
Isolated input UI fixes, turn auto-size back on for target leverage +…

### DIFF
--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageView.kt
@@ -73,7 +73,7 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                 leverageOptions = listOf(
                     LeverageTextAndValue("1.0", "1.0"),
                     LeverageTextAndValue("2.0", "2.0"),
-                    LeverageTextAndValue("2.0", "2.0"),
+                    LeverageTextAndValue("3.0", "3.0"),
                     LeverageTextAndValue("5.0", "5.0"),
                     LeverageTextAndValue("10.0", "10.0"),
                     LeverageTextAndValue("max", "10.0"),
@@ -238,8 +238,7 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                 items = state?.leverageOptions?.map {
                     { modifier ->
                         PlatformSelectionButton(
-                            modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp)
-                                .fillMaxWidth(),
+                            modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp),
                             selected = false,
                         ) {
                             Text(
@@ -257,8 +256,7 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                     { modifier ->
 
                         PlatformSelectionButton(
-                            modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp)
-                                .fillMaxWidth(),
+                            modifier = modifier.sizeIn(minWidth = 48.dp, minHeight = 40.dp),
                             selected = true,
                         ) {
                             Text(
@@ -272,7 +270,7 @@ object DydxTradeInputTargetLeverageView : DydxComponent {
                         }
                     }
                 } ?: listOf(),
-                equalWeight = true,
+                equalWeight = false,
                 currentSelection = state?.leverageOptions?.indexOfFirst {
                     val leverageTextValue = state.parser.asDouble(state.leverageText)
                     it.value.toDouble() == leverageTextValue

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/targetleverage/DydxTradeInputTargetLeverageViewModel.kt
@@ -93,7 +93,7 @@ class DydxTradeInputTargetLeverageViewModel @Inject constructor(
     }
 
     private fun leverageOptions(max: Double): List<LeverageTextAndValue> {
-        val steps = listOf(1.0, 2.0, 5.0, 10.0)
+        val steps = listOf(1.0, 2.0, 3.0, 5.0, 10.0)
         val leverages = mutableListOf<LeverageTextAndValue>()
         for (step in steps) {
             if (max > step) {

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/DydxTradeInputMarginButtonsView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/DydxTradeInputMarginButtonsView.kt
@@ -85,6 +85,7 @@ object DydxTradeInputMarginButtonsView : DydxComponent {
                         .fillMaxWidth(),
                     state = PlatformButtonState.Secondary,
                     text = state.isolatedMarketTargetLeverageText,
+                    fitText = true,
                 ) {
                     state.onTargetLeverage()
                 }


### PR DESCRIPTION

<img width="397" alt="Screenshot 2024-07-06 at 12 56 33 PM" src="https://github.com/dydxprotocol/v4-native-android/assets/163016611/4050251a-3f7d-4749-8e25-6afc5bfe58ef">
<img width="398" alt="Screenshot 2024-07-06 at 12 56 44 PM" src="https://github.com/dydxprotocol/v4-native-android/assets/163016611/54774196-98ca-4616-9f2f-836a56672351">
… scrolling for target leverage options.