### PR TITLE
Fix rare crash of IntervalText

### DIFF
--- a/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/views/IntervalText.kt
+++ b/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/views/IntervalText.kt
@@ -82,15 +82,14 @@ class IntervalTextViewModel @Inject constructor(
 ) : ViewModel() {
     val dateText: MutableStateFlow<String?> = MutableStateFlow(null)
 
-    private val timer = Timer()
+    private var timer: Timer? = null
 
     private var date: Instant? = null
     private var direction: IntervalText.Direction = IntervalText.Direction.COUNT_UP
     private var format: IntervalText.Format = IntervalText.Format.SHORT
 
     override fun onCleared() {
-        timer.cancel()
-        timer.purge()
+        stopTimer()
     }
 
     fun start(date: Instant?, direction: IntervalText.Direction, format: IntervalText.Format) {
@@ -118,7 +117,9 @@ class IntervalTextViewModel @Inject constructor(
 
         timerInterval?.let {
             displayDate()
-            timer.scheduleAtFixedRate(delay = 0, period = it) {
+            stopTimer()
+            timer = Timer()
+            timer?.scheduleAtFixedRate(delay = 0, period = it) {
                 val now = Instant.now()
                 if (direction == IntervalText.Direction.COUNT_DOWN_TO_HOUR && now > date) {
                     date = now.truncatedTo(ChronoUnit.HOURS).plusSeconds(3600)
@@ -126,6 +127,12 @@ class IntervalTextViewModel @Inject constructor(
                 displayDate()
             }
         }
+    }
+
+    private fun stopTimer() {
+        timer?.cancel()
+        timer?.purge()
+        timer = null
     }
 
     private fun displayDate() {


### PR DESCRIPTION
Handling the case where `start() `gets called after `onCleared()`

Crashlytics: [[link](https://console.firebase.google.com/project/dydx-operations-services/crashlytics/app/android:trade.opsdao.dydxchain/issues/2c1c702dfe363838ec000e96320f4481?time=last-seven-days&types=crash&sessionEventKey=66997AFC0359000213AB4FD292CCAC48_1971521096579220917)]