### PR TITLE
Fix a leverage slider crash when positionLeverage is outside the valid range

### DIFF
--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageViewModel.kt
@@ -7,15 +7,12 @@ import exchange.dydx.abacus.output.input.TradeInput
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.state.model.TradeInputField
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
-import exchange.dydx.dydxstatemanager.maxLeverage
 import exchange.dydx.trading.common.DydxViewModel
 import exchange.dydx.trading.common.formatter.DydxFormatter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import javax.inject.Inject
-
-private val TAG = "DydxTradeInputLeverageViewModel"
 
 @HiltViewModel
 class DydxTradeInputLeverageViewModel @Inject constructor(


### PR DESCRIPTION
Crashlytics [[link](https://console.firebase.google.com/project/dydx-operations-services/crashlytics/app/android:trade.opsdao.dydxchain/issues/acd1906d57223df3dba5b9878b9820f3?time=last-seven-days&types=crash&sessionEventKey=669AC9E402F8000115A782762CCA105D_1971890113413388550)]

There might be some rounding error in Abacus that triggered this.  Will look into it further.