### PR TITLE
Fix crash on configsAndAssetMap

### DIFF
--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusState.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusState.kt
@@ -383,7 +383,7 @@ class AbacusState(
             appScope,
         ) { marketMap: Map<String, PerpetualMarket>?, assetMap: Map<String, Asset>? ->
             val output = mutableMapOf<String, MarketConfigsAndAsset>()
-            marketMap?.forEach { (marketId, market) ->
+            marketMap?.entries?.forEach { (marketId, market) ->
                 output[marketId] =
                     MarketConfigsAndAsset(market.configs, assetMap?.get(market.assetId), market.assetId)
             }


### PR DESCRIPTION
".forEach" on a "map" is a muting operation which potentially causes a concurrency exception.  Changed it to use ".entries" that returns an immutable set of entries.

Reference: [[link](https://stackoverflow.com/questions/602636/why-is-a-concurrentmodificationexception-thrown-and-how-to-debug-it)]

Crashlytics: [[link](https://console.firebase.google.com/project/dydx-operations-services/crashlytics/app/android:trade.opsdao.dydxchain/issues/ea0bb6c81ed7195e34cf3dfc1f475dac?time=1720310400000:1721433599000&types=crash&sessionEventKey=669ADD5D005A00017EF82A1F3A5A0AAB_1971910743997752069)]