### PR TITLE
MOB-615 Fix IntervalText issue when displayed in a list

### DIFF
--- a/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/views/IntervalText.kt
+++ b/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/views/IntervalText.kt
@@ -4,10 +4,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import exchange.dydx.platformui.designSystem.theme.dydxDefault
@@ -62,7 +62,7 @@ object IntervalText {
             return
         }
 
-        val viewModel: IntervalTextViewModel = hiltViewModel()
+        val viewModel = remember { IntervalTextViewModel(formatter = DydxFormatter()) }
         LaunchedEffect(Unit) {
             viewModel.start(state.date, state.direction, state.format)
         }


### PR DESCRIPTION
hiltViewModel() is scoped at the navigation graph, so the same instance is used for the entire screen.  Updating it to use "remember"

[untitled.webm](https://github.com/user-attachments/assets/6445834c-2e4c-4a47-8292-20286ddcb246)
