### PR TITLE
Allow null gas estimates for EVM transactions.

### DIFF
--- a/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/deposit/ERC20ApprovalStep.kt
+++ b/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/deposit/ERC20ApprovalStep.kt
@@ -48,7 +48,7 @@ class ERC20ApprovalStep(
             val gasPrice = (gasPriceEvent as? AsyncEvent.Result)?.result
             val gasEstimate = (gasEstimateEvent as? AsyncEvent.Result)?.result
             val nonce = (nonceEvent as? AsyncEvent.Result)?.result
-            if (gasPrice != null && gasEstimate != null && nonce != null) {
+            if (gasPrice != null && nonce != null) {
                 return@combine Triple(gasPrice, gasEstimate, nonce)
             } else {
                 return@combine null


### PR DESCRIPTION
Alchemy RPC doesn't return gas estimates it seems.