### PR TITLE
Fix bug where wallet USDC is not swept for a fresh account.

### DIFF
--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
@@ -44,14 +44,13 @@ class DydxTransferSubaccountWorker(
                         balance != null && balance > balanceRetainAmount
                     },
                 abacusStateManager.state.currentWallet.mapNotNull { it },
-                abacusStateManager.state.selectedSubaccount.mapNotNull { it?.subaccountNumber },
-            ) { balance, wallet, subaccountNumber ->
+            ) { balance, wallet ->
                 val depositAmount = balance?.minus(balanceRetainAmount) ?: 0.0
                 if (depositAmount <= 0) return@combine
                 val amountString = formatter.decimalLocaleAgnostic(depositAmount, abacusStateManager.usdcTokenDecimal)
                     ?: return@combine
 
-                depositToSubaccount(amountString, subaccountNumber, wallet)
+                depositToSubaccount(amountString, abacusStateManager.state.subaccountNumber ?: 0, wallet)
             }
                 .launchIn(scope)
         }

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusState.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/AbacusState.kt
@@ -518,7 +518,7 @@ class AbacusState(
             .mapStateWithThrottle(appScope) { it?.input?.adjustIsolatedMargin }
     }
 
-    private val subaccountNumber: Int?
+    val subaccountNumber: Int?
         get() = parser.asInt(abacusStateManager.subaccountNumber)
 }
 


### PR DESCRIPTION
Before this change, `DydxTransferSubaccountWorker` was listening to `selectedSubaccount` from Abacus. `selectedSubaccount` is basically `subaccounts[subaccountNumber]` but for a fresh account, the Indexer does not return ANY subaccounts. so the `subaccounts[subaccountNumber]` lookup always fails.

The fix here is to reference the `subaccountNumber` on the Abacus state manager itself. This is fine because even in a multi-parent subaccount world, `subaccountNumber` is intended to be a parent subaccount.