### PR TITLE
Fix subaccount worker for new users

### DIFF
--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
@@ -14,12 +14,14 @@ import exchange.dydx.trading.integration.cosmos.CosmosV4WebviewClientProtocol
 import exchange.dydx.utilities.utils.Logging
 import exchange.dydx.utilities.utils.WorkerProtocol
 import exchange.dydx.utilities.utils.jsonStringToMap
+import exchange.dydx.utilities.utils.timerFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @ActivityRetainedScoped
 class DydxTransferSubaccountWorker @Inject constructor(
@@ -44,10 +46,11 @@ class DydxTransferSubaccountWorker @Inject constructor(
             isStarted = true
 
             combine(
+                timerFlow(20.seconds),
                 abacusStateManager.state.accountBalance(abacusStateManager.usdcTokenDenom)
                     .filterNotNull(),
                 abacusStateManager.state.currentWallet.mapNotNull { it },
-            ) { balance, wallet ->
+            ) { _, balance, wallet ->
                 if (balance > balanceRetainAmount) {
                     val depositAmount = balance.minus(balanceRetainAmount)
                     if (depositAmount <= 0) return@combine

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
@@ -47,10 +47,10 @@ class DydxTransferSubaccountWorker @Inject constructor(
 
             combine(
                 timerFlow(20.seconds),
-                abacusStateManager.state.accountBalance(abacusStateManager.usdcTokenDenom)
-                    .filterNotNull(),
+                abacusStateManager.state.accountBalance(abacusStateManager.usdcTokenDenom),
                 abacusStateManager.state.currentWallet.mapNotNull { it },
             ) { _, balance, wallet ->
+                val balance = balance ?: 0.0
                 if (balance > balanceRetainAmount) {
                     val depositAmount = balance.minus(balanceRetainAmount)
                     if (depositAmount <= 0) return@combine


### PR DESCRIPTION
For new users the usdc balance will always be zero or null (if the fund came from Faucet).  But when the first call is triggered, the validator might not yet be connected.  Let's add a timer to fix this.