### PR TITLE
TRA-868 Increase decimal position for vault items

### DIFF
--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/position/DydxMarketPositionButtonsViewModel.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/position/DydxMarketPositionButtonsViewModel.kt
@@ -92,8 +92,9 @@ class DydxMarketPositionButtonsViewModel @Inject constructor(
                         presentation = DydxRouter.Presentation.Modal,
                     )
                 }
-            } else
-                null,
+            } else {
+                null
+            },
         )
     }
 

--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/position/DydxMarketPositionButtonsViewModel.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/position/DydxMarketPositionButtonsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import exchange.dydx.abacus.output.account.SubaccountOrder
 import exchange.dydx.abacus.output.account.SubaccountPosition
+import exchange.dydx.abacus.output.input.MarginMode
 import exchange.dydx.abacus.output.input.OrderType
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
@@ -16,6 +17,7 @@ import exchange.dydx.trading.common.formatter.DydxFormatter
 import exchange.dydx.trading.common.navigation.DydxRouter
 import exchange.dydx.trading.common.navigation.TradeRoutes
 import exchange.dydx.trading.feature.market.marketinfo.streams.MarketInfoStreaming
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -37,6 +39,7 @@ class DydxMarketPositionButtonsViewModel @Inject constructor(
 
     private val includeLimitOrders = abacusStateManager.environment?.featureFlags?.isSlTpLimitOrdersEnabled == true || BuildConfig.DEBUG
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val state: Flow<DydxMarketPositionButtonsView.ViewState?> =
         combine(
             marketIdFlow,
@@ -82,12 +85,15 @@ class DydxMarketPositionButtonsViewModel @Inject constructor(
                 orders = stopLossOrders,
                 configsAndAsset = configsAndAsset,
             ),
-            editMarginAction = {
-                router.navigateTo(
-                    route = TradeRoutes.adjust_margin + "/$marketId",
-                    presentation = DydxRouter.Presentation.Modal,
-                )
-            },
+            editMarginAction = if (position?.marginMode == MarginMode.Isolated) {
+                {
+                    router.navigateTo(
+                        route = TradeRoutes.adjust_margin + "/$marketId",
+                        presentation = DydxRouter.Presentation.Modal,
+                    )
+                }
+            } else
+                null,
         )
     }
 

--- a/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/views/GradientSlider.kt
+++ b/v4/feature/shared/src/main/java/exchange/dydx/trading/feature/shared/views/GradientSlider.kt
@@ -49,7 +49,9 @@ object GradientSlider {
         if (state == null) {
             return
         }
-        assert(state.leftRatio < state.rightRatio)
+        if (state.leftRatio >= state.rightRatio) {
+            return
+        }
 
         val brush: Brush
         val left = abs(state.leftRatio)
@@ -82,7 +84,6 @@ object GradientSlider {
             showLabel = false,
             showIndicator = false,
             thumb = {
-                // CustomSliderDefaults.Thumb("${abs(it)}x")
                 CustomSliderDefaults.Thumb("")
             },
             track = {

--- a/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageView.kt
+++ b/v4/feature/trade/src/main/java/exchange/dydx/trading/feature/trade/tradeinput/components/inputfields/leverage/DydxTradeInputLeverageView.kt
@@ -245,24 +245,26 @@ object DydxTradeInputLeverageView : DydxComponent {
             verticalArrangement = Arrangement.spacedBy(0.dp),
         ) {
             GradientSlider.Content(modifier, sliderViewState)
-            Row() {
-                Text(
-                    text = when (state.side) {
-                        OrderSide.Sell -> "${absMaxLeverage}x"
-                        OrderSide.Buy -> "${absPositionLeverage}x"
-                    },
-                    style = TextStyle.dydxDefault
-                        .themeFont(fontSize = ThemeFont.FontSize.tiny),
-                )
-                Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    text = when (state.side) {
-                        OrderSide.Sell -> "${absPositionLeverage}x"
-                        OrderSide.Buy -> "${absMaxLeverage}x"
-                    },
-                    style = TextStyle.dydxDefault
-                        .themeFont(fontSize = ThemeFont.FontSize.tiny),
-                )
+            if (sliderViewState.leftRatio < sliderViewState.rightRatio) {
+                Row {
+                    Text(
+                        text = when (state.side) {
+                            OrderSide.Sell -> "${absMaxLeverage}x"
+                            OrderSide.Buy -> "${absPositionLeverage}x"
+                        },
+                        style = TextStyle.dydxDefault
+                            .themeFont(fontSize = ThemeFont.FontSize.tiny),
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = when (state.side) {
+                            OrderSide.Sell -> "${absPositionLeverage}x"
+                            OrderSide.Buy -> "${absMaxLeverage}x"
+                        },
+                        style = TextStyle.dydxDefault
+                            .themeFont(fontSize = ThemeFont.FontSize.tiny),
+                    )
+                }
             }
         }
     }

--- a/v4/feature/vault/src/main/java/exchange/dydx/trading/feature/vault/DydxVaultViewModel.kt
+++ b/v4/feature/vault/src/main/java/exchange/dydx/trading/feature/vault/DydxVaultViewModel.kt
@@ -133,11 +133,11 @@ class DydxVaultViewModel @Inject constructor(
             ),
             equity = formatter.dollarVolume(
                 (position.marginUsdc?.absoluteValue ?: 0.0),
-                digits = 0,
+                digits = 2,
             ),
             positionSize = formatter.condensed(
                 (position.currentPosition?.asset?.absoluteValue ?: 0.0),
-                digits = 0,
+                digits = 2,
             ),
             token = asset?.displayableAssetId?.let {
                 TokenTextView.ViewState(


### PR DESCRIPTION
Also fixing:
* A bug where Edit Margin option is incorrectly showing on crossed positions.
* Leverage slider assertion when the user is at max leverage.

![Screenshot_1733157974](https://github.com/user-attachments/assets/39726165-0812-4a06-a841-9780cf80129c)
