### PR TITLE
Fix candle x-axis label issue when resolution is 1 hour

### DIFF
--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DateTimeAxisFormatter.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DateTimeAxisFormatter.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 
 class DateTimeAxisFormatter(
     private val anchorDateTime: Instant,
-    private val candlesPeriod: String?,
+    private val candlesPeriod: CandlePeriod?,
     private val offset: Int,
 ) : ValueAxisFormatter() {
     private val minuteFormatter = DateTimeFormatter.ofPattern("HH:mm")
@@ -16,31 +16,31 @@ class DateTimeAxisFormatter(
 
     override fun getFormattedValue(value: Float): String {
         val datetime = when (candlesPeriod) {
-            "1DAY" -> {
+            CandlePeriod.OneDay -> {
                 anchorDateTime.plusSeconds((value.toLong() - offset) * 3600 * 24)
             }
 
-            "1HOURS" -> {
+            CandlePeriod.OneHour -> {
                 anchorDateTime.plusSeconds((value.toLong() - offset) * 3600)
             }
 
-            "4HOURS" -> {
+            CandlePeriod.FourHours -> {
                 anchorDateTime.plusSeconds(((value * 4).toLong() - offset) * 3600)
             }
 
-            "1MIN" -> {
+            CandlePeriod.OneMinute -> {
                 anchorDateTime.plusSeconds((value.toLong() - offset) * 60)
             }
 
-            "5MINS" -> {
+            CandlePeriod.FiveMinutes -> {
                 anchorDateTime.plusSeconds(((value * 5).toLong() - offset) * 60)
             }
 
-            "15MINS" -> {
+            CandlePeriod.FifteenMinutes -> {
                 anchorDateTime.plusSeconds(((value * 15).toLong() - offset) * 60)
             }
 
-            "30MINS" -> {
+            CandlePeriod.ThirtyMinutes -> {
                 anchorDateTime.plusSeconds(((value * 30).toLong() - offset) * 60)
             }
 
@@ -49,11 +49,11 @@ class DateTimeAxisFormatter(
             }
         }.atZone(java.time.ZoneId.systemDefault()).toLocalDateTime()
         return when (candlesPeriod) {
-            "1DAY", "4HOURS" -> {
+            CandlePeriod.OneDay, CandlePeriod.FourHours -> {
                 datetime.format(dayFormatter)
             }
 
-            "1HOUR" -> {
+            CandlePeriod.OneHour -> {
                 datetime.format(hourFormatter)
             }
 

--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesView.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesView.kt
@@ -382,7 +382,7 @@ object DydxMarketPricesView : DydxComponent {
                             // and the maxXRange is the range for maxXScale
                             // and range and scale are inverse
                             chart.setVisibleXRange(160f, 40f)
-                        }
+                        },
                     )
                 },
             )

--- a/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesView.kt
+++ b/v4/feature/market/src/main/java/exchange/dydx/trading/feature/market/marketinfo/components/prices/DydxMarketPricesView.kt
@@ -372,17 +372,18 @@ object DydxMarketPricesView : DydxComponent {
                         line = if (state.typeOptions.index == 0) null else state.prices,
                         config = state.config,
                         lineColor = null,
-                    ) { lastX ->
-                        // Show 40 items
-                        chart.setVisibleXRange(40f, 40f)
-                        chart.moveViewToX(lastX)
-                        //        chart.moveViewToAnimated(lastX, 0f, YAxis.AxisDependency.RIGHT, 500)
-                        // The minXRange has a higher number than maxXRange
-                        // because the minXRange is the range for minXScale
-                        // and the maxXRange is the range for maxXScale
-                        // and range and scale are inverse
-                        chart.setVisibleXRange(160f, 40f)
-                    }
+                        updateRange = { lastX ->
+                            // Show 40 items
+                            chart.setVisibleXRange(40f, 40f)
+                            chart.moveViewToX(lastX)
+                            //        chart.moveViewToAnimated(lastX, 0f, YAxis.AxisDependency.RIGHT, 500)
+                            // The minXRange has a higher number than maxXRange
+                            // because the minXRange is the range for minXScale
+                            // and the maxXRange is the range for maxXScale
+                            // and range and scale are inverse
+                            chart.setVisibleXRange(160f, 40f)
+                        }
+                    )
                 },
             )
         }


### PR DESCRIPTION
Caused by a typo in the code ("1HOURS" instead of "1HOUR").  Now changing this to enum.