### PR TITLE
Add default wallets for WalletConnect Modal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ plugins {
     id "com.diffplug.spotless" version "6.22.0" // apply false
     id 'com.autonomousapps.dependency-analysis' version "1.17.0" // apply false
     id "com.dorongold.task-tree" version "2.1.0"
-    id 'nebula.lint' version '19.0.1'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.ktlintVersion = '0.48.0'
     ext.kotlinVersion = '1.9.24'
-    ext.androidApplicationVersion = '8.8.2'
+    ext.androidApplicationVersion = '8.9.0'
 
     repositories {
         google()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jan 30 10:45:32 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/v4/app/src/main/java/exchange/dydx/trading/AppModule.kt
+++ b/v4/app/src/main/java/exchange/dydx/trading/AppModule.kt
@@ -28,6 +28,8 @@ import exchange.dydx.dydxstatemanager.clientState.favorite.DydxFavoriteStore
 import exchange.dydx.dydxstatemanager.clientState.favorite.DydxFavoriteStoreProtocol
 import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferStateManager
 import exchange.dydx.dydxstatemanager.clientState.transfers.DydxTransferStateManagerProtocol
+import exchange.dydx.dydxstatemanager.clientState.walletmodal.DydxWalletModalStore
+import exchange.dydx.dydxstatemanager.clientState.walletmodal.DydxWalletModalStoreProtocol
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletStateManager
 import exchange.dydx.dydxstatemanager.clientState.wallets.DydxWalletStateManagerProtocol
 import exchange.dydx.dydxstatemanager.protocolImplementations.AbacusChainImp
@@ -188,6 +190,9 @@ interface AppModule {
 
     @Binds
     fun bindUserFavoriteStoreProtocol(dydxFavoriteStore: DydxFavoriteStore): DydxFavoriteStoreProtocol
+
+    @Binds
+    fun bindWalletModalStoreProtocol(dydxWalletModalStore: DydxWalletModalStore): DydxWalletModalStoreProtocol
 
     @Binds
     fun bindCompositeTracking(compositeTracker: CompositeTracker): CompositeTracking

--- a/v4/core/src/main/java/exchange/dydx/trading/core/CarteraSetup.kt
+++ b/v4/core/src/main/java/exchange/dydx/trading/core/CarteraSetup.kt
@@ -46,7 +46,7 @@ object CarteraSetup {
         CarteraConfig.shared = CarteraConfig(
             walletProvidersConfig = getWalletProvidersConfig(
                 activity.applicationContext,
-                abacusStateManager
+                abacusStateManager,
             ),
             application = activity.application,
             launcher = launcher,

--- a/v4/core/src/main/java/exchange/dydx/trading/core/CarteraSetup.kt
+++ b/v4/core/src/main/java/exchange/dydx/trading/core/CarteraSetup.kt
@@ -33,13 +33,21 @@ object CarteraSetup {
     }
 
     private fun setUpCartera(activity: FragmentActivity, abacusStateManager: AbacusStateManagerProtocol) {
-        val launcher = activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            val uri = result.data?.data ?: return@registerForActivityResult
-            CarteraConfig.handleResponse(uri)
+        if (CarteraConfig.shared != null) {
+            return
         }
 
+        val launcher =
+            activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                val uri = result.data?.data ?: return@registerForActivityResult
+                CarteraConfig.handleResponse(uri)
+            }
+
         CarteraConfig.shared = CarteraConfig(
-            walletProvidersConfig = getWalletProvidersConfig(activity.applicationContext, abacusStateManager),
+            walletProvidersConfig = getWalletProvidersConfig(
+                activity.applicationContext,
+                abacusStateManager
+            ),
             application = activity.application,
             launcher = launcher,
         )

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
@@ -55,7 +55,7 @@ class DydxCarteraConfigWorker @Inject constructor(
                 }
             }
 
-            // WalletConnect Modal's init() can't wait until the wallets.json is loaded, so we
+            // WalletConnect Modal's init() can't wait until the wallet ids from the env.json is loaded, so we
             // just load from the cached value.
             CarteraConfig.shared?.updateModalConfig(WalletConnectModalConfig(walletIds = walletModalStore.state.value?.walletIds))
 

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
@@ -2,6 +2,8 @@ package exchange.dydx.trading.feature.workers.globalworkers
 
 import android.app.Application
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import exchange.dydx.cartera.CarteraConfig
 import exchange.dydx.cartera.WalletConnectModalConfig
@@ -9,6 +11,9 @@ import exchange.dydx.cartera.WalletConnectV2Config
 import exchange.dydx.cartera.WalletProvidersConfig
 import exchange.dydx.cartera.WalletSegueConfig
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
+import exchange.dydx.dydxstatemanager.clientState.walletmodal.DydxWalletModal
+import exchange.dydx.dydxstatemanager.clientState.walletmodal.DydxWalletModalStore
+import exchange.dydx.dydxstatemanager.clientState.walletmodal.DydxWalletModalStoreProtocol
 import exchange.dydx.trading.common.BuildConfig
 import exchange.dydx.trading.common.R
 import exchange.dydx.trading.common.di.CoroutineScopes
@@ -16,8 +21,11 @@ import exchange.dydx.utilities.utils.CachedFileLoader
 import exchange.dydx.utilities.utils.Logging
 import exchange.dydx.utilities.utils.WorkerProtocol
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import java.net.URL
 import javax.inject.Inject
 
 private const val TAG = "DydxCarteraConfigWorker"
@@ -29,6 +37,7 @@ class DydxCarteraConfigWorker @Inject constructor(
     private val cachedFileLoader: CachedFileLoader,
     private val application: Application,
     private val logger: Logging,
+    private val walletModalStore: DydxWalletModalStoreProtocol,
 ) : WorkerProtocol {
     override var isStarted = false
 
@@ -46,11 +55,16 @@ class DydxCarteraConfigWorker @Inject constructor(
                 }
             }
 
+            // WalletConnect Modal's init() can't wait until the wallets.json is loaded, so we
+            // just load from the cached value.
+            CarteraConfig.shared?.updateModalConfig(WalletConnectModalConfig(walletIds = walletModalStore.state.value?.walletIds))
+
+            // Update the cached value when the environment changes
             abacusStateManager.currentEnvironmentId.onEach { _ ->
                 val config = WalletProvidersConfigUtil.getWalletProvidersConfig(application, abacusStateManager)
-                val modalConfig = config.walletConnectModal
-                if (modalConfig != null) {
-                    CarteraConfig.shared?.updateModalConfig(modalConfig)
+                val walletIds = config.walletConnectModal?.walletIds
+                if (!walletIds.isNullOrEmpty()) {
+                    walletModalStore.update((DydxWalletModal(walletIds = walletIds)))
                 }
             }
                 .launchIn(scope)

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxCarteraConfigWorker.kt
@@ -2,8 +2,6 @@ package exchange.dydx.trading.feature.workers.globalworkers
 
 import android.app.Application
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import exchange.dydx.cartera.CarteraConfig
 import exchange.dydx.cartera.WalletConnectModalConfig
@@ -12,7 +10,6 @@ import exchange.dydx.cartera.WalletProvidersConfig
 import exchange.dydx.cartera.WalletSegueConfig
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.dydxstatemanager.clientState.walletmodal.DydxWalletModal
-import exchange.dydx.dydxstatemanager.clientState.walletmodal.DydxWalletModalStore
 import exchange.dydx.dydxstatemanager.clientState.walletmodal.DydxWalletModalStoreProtocol
 import exchange.dydx.trading.common.BuildConfig
 import exchange.dydx.trading.common.R
@@ -21,11 +18,8 @@ import exchange.dydx.utilities.utils.CachedFileLoader
 import exchange.dydx.utilities.utils.Logging
 import exchange.dydx.utilities.utils.WorkerProtocol
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
-import java.net.URL
 import javax.inject.Inject
 
 private const val TAG = "DydxCarteraConfigWorker"

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/clientState/walletmodal/DydxWalletModal.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/clientState/walletmodal/DydxWalletModal.kt
@@ -1,0 +1,63 @@
+package exchange.dydx.dydxstatemanager.clientState.walletmodal
+
+import exchange.dydx.dydxstatemanager.clientState.DydxClientState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.Serializable
+import javax.inject.Inject
+import javax.inject.Singleton
+
+interface DydxWalletModalStoreProtocol {
+    val state: StateFlow<DydxWalletModal?>
+    fun update(walletModal: DydxWalletModal)
+    fun clear()
+}
+
+@Singleton
+class DydxWalletModalStore @Inject constructor(
+    private val clientState: DydxClientState,
+) : DydxWalletModalStoreProtocol {
+    companion object {
+        private const val storeKey = "AbacusStateManager.WalletModalStore"
+        private val storeType: DydxClientState.StorageType = DydxClientState.StorageType.SharedPreferences
+    }
+
+    private val mutableState = MutableStateFlow<DydxWalletModal?>(null)
+
+    init {
+        val state: DydxWalletModal? = clientState.load(storeKey, storeType)
+        mutableState.value = state ?: DydxWalletModal.default
+    }
+
+    override val state: StateFlow<DydxWalletModal?> = mutableState
+
+    override fun update(walletModal: DydxWalletModal) {
+        mutableState.value = walletModal
+        clientState.store(walletModal, storeKey)
+    }
+    override fun clear() {
+        val current = DydxWalletModal(walletIds = emptyList())
+        mutableState.value = current
+        clientState.store(current, storeKey)
+    }
+}
+
+@Serializable
+data class DydxWalletModal(
+    val walletIds: List<String> = listOf(),
+) {
+    companion object {
+        val default = DydxWalletModal(
+            walletIds = listOf(
+                "c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96",
+                "4622a2b2d6af1c9844944291e5e7351a6aa24cd7b23099efac1b2fd875da31a0",
+                "971e689d0a5be527bac79629b4ee9b925e82208e5168b733496a09c0faed0709",
+                "c03dfee351b6fcc421b4494ea33b9d4b92a984f87aa76d1663bb28705e95034a",
+                "1ae92b26df02f0abca6304df07debccd18262fdf5fe82daa81593582dac9a369",
+                "ecc4036f814562b41a5268adc86270fba1365471402006302e70169465b7ac18",
+                "c286eebc742a537cd1d6818363e9dc53b21759a1e8e5d9b263d0c03ec7703576",
+                "38f5d18bd8522c244bdd70cb4a68e0e718865155811c043f052fb9f1c51de662"
+            )
+        )
+    }
+}

--- a/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/clientState/walletmodal/DydxWalletModal.kt
+++ b/v4/integration/dydxStateManager/src/main/java/exchange/dydx/dydxstatemanager/clientState/walletmodal/DydxWalletModal.kt
@@ -56,8 +56,8 @@ data class DydxWalletModal(
                 "1ae92b26df02f0abca6304df07debccd18262fdf5fe82daa81593582dac9a369",
                 "ecc4036f814562b41a5268adc86270fba1365471402006302e70169465b7ac18",
                 "c286eebc742a537cd1d6818363e9dc53b21759a1e8e5d9b263d0c03ec7703576",
-                "38f5d18bd8522c244bdd70cb4a68e0e718865155811c043f052fb9f1c51de662"
-            )
+                "38f5d18bd8522c244bdd70cb4a68e0e718865155811c043f052fb9f1c51de662",
+            ),
         )
     }
 }


### PR DESCRIPTION
WalletConnect Modal SDK needs the init() to be called as soon as the app launches, so we can't wait until the wallet IDs from env.json is loaded.   We will store the wallet IDs from env.json to local storage, and load them at app launch.  For the first app launch, we will just use a default list.

