### PR TITLE
Fix subaccount balance transfer issue

### DIFF
--- a/v4/app/build.gradle
+++ b/v4/app/build.gradle
@@ -19,7 +19,7 @@ android {
         minSdkVersion parent.minSdkVersion
         targetSdkVersion parent.targetSdkVersion
         versionCode 10000
-        versionName "1.12.8"
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
@@ -15,8 +15,10 @@ import exchange.dydx.utilities.utils.Logging
 import exchange.dydx.utilities.utils.WorkerProtocol
 import exchange.dydx.utilities.utils.jsonStringToMap
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
@@ -39,31 +41,50 @@ class DydxTransferSubaccountWorker @Inject constructor(
 
     override var isStarted = false
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun start() {
         if (!isStarted) {
             isStarted = true
 
-            combine(
-                abacusStateManager.state.accountBalance(abacusStateManager.usdcTokenDenom)
-                    .filterNotNull(),
-                abacusStateManager.state.currentWallet.mapNotNull { it },
-            ) { balance, wallet ->
-                if (balance > balanceRetainAmount) {
-                    val depositAmount = balance.minus(balanceRetainAmount)
-                    if (depositAmount <= 0) return@combine
-                    val amountString = formatter.decimalLocaleAgnostic(depositAmount, abacusStateManager.usdcTokenDecimal)
-                        ?: return@combine
+            // wait for the environment to be loaded before loading the balance
+            abacusStateManager.currentEnvironmentId
+                .flatMapLatest {
+                    combine(
+                        abacusStateManager.state.accountBalance(abacusStateManager.usdcTokenDenom)
+                            .filterNotNull(),
+                        abacusStateManager.state.currentWallet.mapNotNull { it },
+                    ) { balance, wallet ->
+                        if (balance > balanceRetainAmount) {
+                            val depositAmount = balance.minus(balanceRetainAmount)
+                            if (depositAmount <= 0) return@combine
+                            val amountString = formatter.decimalLocaleAgnostic(
+                                depositAmount,
+                                abacusStateManager.usdcTokenDecimal
+                            )
+                                ?: return@combine
 
-                    depositToSubaccount(amountString, abacusStateManager.state.subaccountNumber ?: 0, wallet)
-                } else if (balance < rebalanceThreshold) {
-                    val withdrawAmount = balanceRetainAmount.minus(balance)
-                    if (withdrawAmount <= 0) return@combine
-                    val amountString = formatter.decimalLocaleAgnostic(withdrawAmount, abacusStateManager.usdcTokenDecimal)
-                        ?: return@combine
+                            depositToSubaccount(
+                                amountString = amountString,
+                                subaccountNumber = abacusStateManager.state.subaccountNumber ?: 0,
+                                wallet = wallet
+                            )
+                        } else if (balance < rebalanceThreshold) {
+                            val withdrawAmount = balanceRetainAmount.minus(balance)
+                            if (withdrawAmount <= 0) return@combine
+                            val amountString = formatter.decimalLocaleAgnostic(
+                                withdrawAmount,
+                                abacusStateManager.usdcTokenDecimal
+                            )
+                                ?: return@combine
 
-                    withdrawFromSubaccount(amountString, abacusStateManager.state.subaccountNumber ?: 0, wallet)
+                            withdrawFromSubaccount(
+                                amountString = amountString,
+                                subaccountNumber = abacusStateManager.state.subaccountNumber ?: 0,
+                                wallet = wallet
+                            )
+                        }
+                    }
                 }
-            }
                 .launchIn(scope)
         }
     }

--- a/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
+++ b/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxTransferSubaccountWorker.kt
@@ -59,28 +59,28 @@ class DydxTransferSubaccountWorker @Inject constructor(
                             if (depositAmount <= 0) return@combine
                             val amountString = formatter.decimalLocaleAgnostic(
                                 depositAmount,
-                                abacusStateManager.usdcTokenDecimal
+                                abacusStateManager.usdcTokenDecimal,
                             )
                                 ?: return@combine
 
                             depositToSubaccount(
                                 amountString = amountString,
                                 subaccountNumber = abacusStateManager.state.subaccountNumber ?: 0,
-                                wallet = wallet
+                                wallet = wallet,
                             )
                         } else if (balance < rebalanceThreshold) {
                             val withdrawAmount = balanceRetainAmount.minus(balance)
                             if (withdrawAmount <= 0) return@combine
                             val amountString = formatter.decimalLocaleAgnostic(
                                 withdrawAmount,
-                                abacusStateManager.usdcTokenDecimal
+                                abacusStateManager.usdcTokenDecimal,
                             )
                                 ?: return@combine
 
                             withdrawFromSubaccount(
                                 amountString = amountString,
                                 subaccountNumber = abacusStateManager.state.subaccountNumber ?: 0,
-                                wallet = wallet
+                                wallet = wallet,
                             )
                         }
                     }


### PR DESCRIPTION
It's another issue caused by recent change of the app startup sequence.  The app needs to wait for the Abacus environment to be loaded first before checking the balance (otherwise the token denom will be null).
