### PR TITLE
Fix transfer equity receipt item

### DIFF
--- a/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/components/equity/DydxReceiptEquityViewModel.kt
+++ b/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/components/equity/DydxReceiptEquityViewModel.kt
@@ -3,31 +3,61 @@ package exchange.dydx.trading.feature.receipt.components.equity
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import exchange.dydx.abacus.output.account.Subaccount
+import exchange.dydx.abacus.output.input.TransferInput
+import exchange.dydx.abacus.output.input.TransferInputSummary
+import exchange.dydx.abacus.output.input.TransferType
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.trading.common.DydxViewModel
 import exchange.dydx.trading.common.formatter.DydxFormatter
+import exchange.dydx.trading.feature.receipt.ReceiptType
+import exchange.dydx.trading.feature.receipt.streams.ReceiptStreaming
 import exchange.dydx.trading.feature.shared.views.AmountText
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import kotlin.math.max
 
 @HiltViewModel
 class DydxReceiptEquityViewModel @Inject constructor(
     private val localizer: LocalizerProtocol,
     private val abacusStateManager: AbacusStateManagerProtocol,
     private val formatter: DydxFormatter,
+    private val receiptTypeFlow: Flow<@JvmSuppressWildcards ReceiptType?>,
+    private val receiptStream: ReceiptStreaming,
 ) : ViewModel(), DydxViewModel {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val state: Flow<DydxReceiptEquityView.ViewState?> =
-        abacusStateManager.state.selectedSubaccount
-            .map {
-                createViewState(it)
+        receiptTypeFlow
+            .flatMapLatest { receiptType ->
+                when (receiptType) {
+                    is ReceiptType.Trade -> {
+                        abacusStateManager.state.selectedSubaccount
+                            .map {
+                                createTradeViewState(it)
+                            }
+                    }
+                    is ReceiptType.Transfer -> {
+                        combine(
+                            abacusStateManager.state.selectedSubaccount,
+                            abacusStateManager.state.transferInput,
+                            receiptStream.transferSummaryFlow,
+                        ) { subaccount, transferInput, summary ->
+                            createTransferViewState(subaccount, transferInput, summary)
+                        }
+                    }
+                    else -> flowOf()
+                }
             }
             .distinctUntilChanged()
 
-    private fun createViewState(
+    private fun createTradeViewState(
         subaccount: Subaccount?
     ): DydxReceiptEquityView.ViewState {
         return DydxReceiptEquityView.ViewState(
@@ -47,6 +77,47 @@ class DydxReceiptEquityViewModel @Inject constructor(
                     localizer = localizer,
                     formatter = formatter,
                     amount = subaccount.equity?.postOrder,
+                    tickSize = 2,
+                )
+            } else {
+                null
+            },
+        )
+    }
+
+    private fun createTransferViewState(
+        subaccount: Subaccount?,
+        transferInput: TransferInput?,
+        summary: TransferInputSummary?,
+    ): DydxReceiptEquityView.ViewState {
+        val transferUsdcSize = when (transferInput?.type) {
+            TransferType.deposit -> summary?.toAmountUSD
+            TransferType.withdrawal, TransferType.transferOut -> summary?.usdcSize
+            else -> null
+        }
+        val currentEquity = subaccount?.equity?.current
+
+        return DydxReceiptEquityView.ViewState(
+            localizer = localizer,
+            before = if (currentEquity != null) {
+                AmountText.ViewState(
+                    localizer = localizer,
+                    formatter = formatter,
+                    amount = currentEquity,
+                    tickSize = 2,
+                )
+            } else {
+                null
+            },
+            after = if (transferUsdcSize != null && currentEquity != null) {
+                AmountText.ViewState(
+                    localizer = localizer,
+                    formatter = formatter,
+                    amount = when (transferInput?.type) {
+                        TransferType.deposit -> currentEquity + transferUsdcSize
+                        TransferType.withdrawal, TransferType.transferOut -> max(0.0, currentEquity - transferUsdcSize)
+                        else -> currentEquity
+                    },
                     tickSize = 2,
                 )
             } else {

--- a/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/di/ReceiptModule.kt
+++ b/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/di/ReceiptModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.scopes.ActivityRetainedScoped
 import exchange.dydx.trading.feature.receipt.ReceiptType
 import exchange.dydx.trading.feature.receipt.streams.ReceiptStream
 import exchange.dydx.trading.feature.receipt.streams.ReceiptStreaming
+import exchange.dydx.trading.feature.receipt.streams.TransferRouteSelectionInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -31,6 +32,12 @@ interface ReceiptModule {
         @ActivityRetainedScoped
         fun provideMutableReceiptTypeFlow(): MutableStateFlow<ReceiptType?> {
             return MutableStateFlow(null)
+        }
+
+        @Provides
+        @ActivityRetainedScoped
+        fun provideTransferRouteSelectionInfo(): TransferRouteSelectionInfo {
+            return TransferRouteSelectionInfo()
         }
     }
 }

--- a/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/streams/ReceiptStream.kt
+++ b/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/streams/ReceiptStream.kt
@@ -1,6 +1,8 @@
 package exchange.dydx.trading.feature.receipt.streams
 
 import exchange.dydx.abacus.output.input.TradeInputSummary
+import exchange.dydx.abacus.output.input.TransferInputSummary
+import exchange.dydx.abacus.output.input.TransferType
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.trading.feature.receipt.ReceiptType
 import exchange.dydx.trading.feature.receipt.TradeReceiptType
@@ -11,11 +13,13 @@ import javax.inject.Inject
 
 interface ReceiptStreaming {
     val tradeSummaryFlow: Flow<Pair<TradeInputSummary?, String?>?>
+    val transferSummaryFlow: Flow<TransferInputSummary?>
 }
 
 class ReceiptStream @Inject constructor(
     abacusStateManager: AbacusStateManagerProtocol,
     receiptTypeFlow: Flow<@JvmSuppressWildcards ReceiptType?>,
+    transferRouteSelectionInfo: TransferRouteSelectionInfo,
 ) : ReceiptStreaming {
 
     override val tradeSummaryFlow: Flow<Pair<TradeInputSummary?, String?>?> =
@@ -34,6 +38,26 @@ class ReceiptStream @Inject constructor(
                 else -> {
                     null
                 }
+            }
+        }
+            .distinctUntilChanged()
+
+    override val transferSummaryFlow: Flow<TransferInputSummary?> =
+        combine(
+            abacusStateManager.state.transferInput,
+            transferRouteSelectionInfo.selected,
+        ) { transferInput, selectedRoute ->
+            when (transferInput?.type) {
+                TransferType.deposit -> {
+                    when (selectedRoute) {
+                        TransferRouteSelection.Instant ->
+                            transferInput.goFastSummary
+
+                        TransferRouteSelection.Regular ->
+                            transferInput.summary
+                    }
+                }
+                else -> transferInput?.summary
             }
         }
             .distinctUntilChanged()

--- a/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/streams/TransferRouteSelectionInfo.kt
+++ b/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/streams/TransferRouteSelectionInfo.kt
@@ -1,4 +1,4 @@
-package exchange.dydx.trading.feature.transfer.utils
+package exchange.dydx.trading.feature.receipt.streams
 
 import kotlinx.coroutines.flow.MutableStateFlow
 

--- a/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/components/InstantSelector.kt
+++ b/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/components/InstantSelector.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.SnackbarDefaults.backgroundColor
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -31,8 +29,8 @@ import exchange.dydx.platformui.designSystem.theme.themeColor
 import exchange.dydx.platformui.designSystem.theme.themeFont
 import exchange.dydx.platformui.theme.DydxThemedPreviewSurface
 import exchange.dydx.platformui.theme.MockLocalizer
+import exchange.dydx.trading.feature.receipt.streams.TransferRouteSelection
 import exchange.dydx.trading.feature.shared.R
-import exchange.dydx.trading.feature.transfer.utils.TransferRouteSelection
 
 @Preview
 @Composable

--- a/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/deposit/DydxTransferDepositCtaButtonModel.kt
+++ b/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/deposit/DydxTransferDepositCtaButtonModel.kt
@@ -24,7 +24,8 @@ import exchange.dydx.trading.common.formatter.DydxFormatter
 import exchange.dydx.trading.common.navigation.DydxRouter
 import exchange.dydx.trading.common.navigation.OnboardingRoutes
 import exchange.dydx.trading.common.navigation.TransferRoutes
-import exchange.dydx.trading.common.navigation.VaultRoutes.deposit
+import exchange.dydx.trading.feature.receipt.streams.TransferRouteSelection
+import exchange.dydx.trading.feature.receipt.streams.TransferRouteSelectionInfo
 import exchange.dydx.trading.feature.shared.TransferTokenDetails
 import exchange.dydx.trading.feature.shared.analytics.OnboardingAnalytics
 import exchange.dydx.trading.feature.shared.analytics.TransferAnalytics
@@ -34,8 +35,6 @@ import exchange.dydx.trading.feature.transfer.DydxTransferError
 import exchange.dydx.trading.feature.transfer.deposit.steps.DydxTransferDepositStep
 import exchange.dydx.trading.feature.transfer.tokenAddress
 import exchange.dydx.trading.feature.transfer.utils.DydxTransferInstanceStoring
-import exchange.dydx.trading.feature.transfer.utils.TransferRouteSelection
-import exchange.dydx.trading.feature.transfer.utils.TransferRouteSelectionInfo
 import exchange.dydx.trading.feature.transfer.utils.chainName
 import exchange.dydx.trading.feature.transfer.utils.networkName
 import exchange.dydx.trading.integration.analytics.tracking.Tracking

--- a/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/deposit/DydxTransferInstantDepositViewModel.kt
+++ b/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/deposit/DydxTransferInstantDepositViewModel.kt
@@ -1,7 +1,5 @@
 package exchange.dydx.trading.feature.transfer.deposit
 
-import android.R.attr.type
-import android.R.id.input
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import exchange.dydx.abacus.output.input.TransferInput
@@ -15,13 +13,12 @@ import exchange.dydx.trading.common.formatter.DydxFormatter
 import exchange.dydx.trading.common.navigation.DydxRouter
 import exchange.dydx.trading.common.navigation.OnboardingRoutes
 import exchange.dydx.trading.common.navigation.TransferRoutes
+import exchange.dydx.trading.feature.receipt.streams.TransferRouteSelection
+import exchange.dydx.trading.feature.receipt.streams.TransferRouteSelectionInfo
 import exchange.dydx.trading.feature.shared.TransferTokenDetails
 import exchange.dydx.trading.feature.shared.TransferTokenInfo
 import exchange.dydx.trading.feature.transfer.components.InstantInputBox
 import exchange.dydx.trading.feature.transfer.components.InstantSelector
-import exchange.dydx.trading.feature.transfer.utils.TransferRouteSelection
-import exchange.dydx.trading.feature.transfer.utils.TransferRouteSelectionInfo
-import jnr.ffi.provider.jffi.CodegenUtils.params
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/deposit/steps/DydxTransferDepositStep.kt
+++ b/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/deposit/steps/DydxTransferDepositStep.kt
@@ -3,9 +3,9 @@ package exchange.dydx.trading.feature.transfer.deposit.steps
 import android.content.Context
 import exchange.dydx.abacus.output.input.TransferInput
 import exchange.dydx.cartera.CarteraProvider
+import exchange.dydx.trading.feature.receipt.streams.TransferRouteSelection
 import exchange.dydx.trading.feature.shared.TransferTokenDetails
 import exchange.dydx.trading.feature.transfer.tokenSize
-import exchange.dydx.trading.feature.transfer.utils.TransferRouteSelection
 import exchange.dydx.utilities.utils.AsyncStep
 import exchange.dydx.utilities.utils.runWithLogs
 import kotlin.io.encoding.ExperimentalEncodingApi

--- a/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/di/TransferModule.kt
+++ b/v4/feature/transfer/src/main/java/exchange/dydx/trading/feature/transfer/di/TransferModule.kt
@@ -12,7 +12,6 @@ import exchange.dydx.trading.feature.transfer.DydxTransferSectionsView
 import exchange.dydx.trading.feature.transfer.search.DydxTransferSearchParam
 import exchange.dydx.trading.feature.transfer.utils.DydxTransferInstanceStore
 import exchange.dydx.trading.feature.transfer.utils.DydxTransferInstanceStoring
-import exchange.dydx.trading.feature.transfer.utils.TransferRouteSelectionInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -68,12 +67,6 @@ interface TransferModule {
         @ActivityRetainedScoped
         fun provideMutableScreenResult(): MutableStateFlow<DydxScreenResult?> {
             return MutableStateFlow(null)
-        }
-
-        @Provides
-        @ActivityRetainedScoped
-        fun provideTransferRouteSelectionInfo(): TransferRouteSelectionInfo {
-            return TransferRouteSelectionInfo()
         }
     }
 }


### PR DESCRIPTION
The abacus equity calculation is incorrect when there are isolated positions, which impacts the transfer receipt. 