### PR TITLE
ENG-536 Update UI for the Sep reward program

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
         minSdkVersion parent.minSdkVersion
         targetSdkVersion parent.targetSdkVersion
         versionCode 10000
-        versionName "1.12.17"
+        versionName "1.12.18"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/app/src/main/assets/features.json
+++ b/android/app/src/main/assets/features.json
@@ -72,6 +72,26 @@
                         }
                     ]
                 }
+            },
+             {
+                "title":{
+                    "text":"Rewards Sep 2025"
+                },
+                "field":{
+                    "field":"ff_rewards_sep_2025",
+                    "optional":true,
+                    "type" : "text",
+                    "options" : [
+                        {
+                            "text": "yes",
+                            "value" : "1"
+                        },
+                        {
+                            "text": "no",
+                            "value" : "0"
+                        }
+                    ]
+                }
             }
         ]
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 buildscript {
     ext.ktlintVersion = '0.48.0'
     ext.kotlinVersion = '2.0.21'
-    ext.androidApplicationVersion = '8.12.1'
+    ext.androidApplicationVersion = '8.12.2'
 
     ext.navigationVersion = '2.9.1'
     ext.hiltVersion = '2.57.1'

--- a/android/v4/common/src/main/java/exchange/dydx/trading/common/featureflags/DydxFeatureFlags.kt
+++ b/android/v4/common/src/main/java/exchange/dydx/trading/common/featureflags/DydxFeatureFlags.kt
@@ -32,7 +32,8 @@ enum class DydxBoolFeatureFlag {
     force_mainnet,
     ff_vault_enabled,
     ff_turnkey_android,
-    ff_prompt_app_rating;
+    ff_prompt_app_rating,
+    ff_rewards_sep_2025;
 
     val defaultValue: Boolean
         get() {
@@ -41,6 +42,7 @@ enum class DydxBoolFeatureFlag {
                 ff_vault_enabled -> true
                 ff_turnkey_android -> false
                 ff_prompt_app_rating -> true
+                ff_rewards_sep_2025 -> false
             }
         }
 }

--- a/android/v4/feature/profile/src/main/java/exchange/dydx/trading/feature/profile/components/DydxProfileLaunchIncentivesView.kt
+++ b/android/v4/feature/profile/src/main/java/exchange/dydx/trading/feature/profile/components/DydxProfileLaunchIncentivesView.kt
@@ -23,12 +23,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontVariation.weight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import exchange.dydx.abacus.protocols.LocalizerProtocol
+import exchange.dydx.abacus.protocols.localizeWithParams
 import exchange.dydx.platformui.components.buttons.PlatformButton
 import exchange.dydx.platformui.components.buttons.PlatformButtonState
 import exchange.dydx.platformui.components.icons.PlatformImage
@@ -64,6 +66,7 @@ object DydxProfileLaunchIncentivesView : DydxComponent {
         val points: String?,
         val aboutAction: () -> Unit = {},
         val leaderboardAction: () -> Unit = {},
+        val isSep2025: Boolean = false
     ) {
         companion object {
             val preview = ViewState(
@@ -113,13 +116,28 @@ object DydxProfileLaunchIncentivesView : DydxComponent {
                 modifier = modifier
                     .padding(vertical = ThemeShapes.VerticalPadding),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
+                val header = if (state.isSep2025) {
+                    state.localizer.localize("APP.REWARDS_SURGE_APRIL_2025.SURGE") + ": " +
+                        state.localizer.localizeWithParams(
+                            path = "APP.REWARDS_SURGE_APRIL_2025.SURGE_HEADLINE_SEP_2025",
+                            params = mapOf(
+                                "REWARD_AMOUNT" to "$1M",
+                                "REBATE_PERCENT" to "50%",
+                            ),
+                        )
+                } else {
+                    state.localizer.localize("APP.REWARDS_SURGE_APRIL_2025.SURGE_HEADLINE")
+                }
                 Text(
-                    text = state.localizer.localize("APP.REWARDS_SURGE_APRIL_2025.SURGE_HEADLINE"),
+                    text = header,
                     style = TextStyle.dydxDefault
                         .themeColor(ThemeColor.SemanticColor.text_primary)
                         .themeFont(fontSize = ThemeFont.FontSize.medium),
+                    modifier = Modifier.weight(1f),
                 )
+
                 Text(
                     text = state.localizer.localize("APP.GENERAL.ACTIVE"),
                     style = TextStyle.dydxDefault
@@ -144,10 +162,21 @@ object DydxProfileLaunchIncentivesView : DydxComponent {
                     .padding(vertical = ThemeShapes.VerticalPadding),
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
+                val body = if (state.isSep2025) {
+                    state.localizer.localizeWithParams(
+                        path = "APP.REWARDS_SURGE_APRIL_2025.SURGE_BODY_SEP_2025",
+                        params = mapOf(
+                            "REWARD_AMOUNT" to "$1M",
+                            "REBATE_PERCENT" to "50%",
+                        ),
+                    )
+                } else {
+                    state.localizer.localize(
+                        path = "APP.REWARDS_SURGE_APRIL_2025.SURGE_BODY",
+                    )
+                }
                 Text(
-                    text = state.localizer.localize(
-                        "APP.REWARDS_SURGE_APRIL_2025.SURGE_BODY",
-                    ),
+                    text = body,
                     style = TextStyle.dydxDefault
                         .themeColor(ThemeColor.SemanticColor.text_tertiary)
                         .themeFont(fontSize = ThemeFont.FontSize.medium),

--- a/android/v4/feature/profile/src/main/java/exchange/dydx/trading/feature/profile/components/DydxProfileLaunchIncentivesViewModel.kt
+++ b/android/v4/feature/profile/src/main/java/exchange/dydx/trading/feature/profile/components/DydxProfileLaunchIncentivesViewModel.kt
@@ -7,6 +7,8 @@ import exchange.dydx.abacus.output.LaunchIncentivePoints
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.trading.common.DydxViewModel
+import exchange.dydx.trading.common.featureflags.DydxBoolFeatureFlag
+import exchange.dydx.trading.common.featureflags.DydxFeatureFlags
 import exchange.dydx.trading.common.formatter.DydxFormatter
 import exchange.dydx.trading.common.navigation.DydxRouter
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +22,7 @@ class DydxProfileLaunchIncentivesViewModel @Inject constructor(
     private val abacusStateManager: AbacusStateManagerProtocol,
     private val formatter: DydxFormatter,
     private val router: DydxRouter,
+    private val featureFlags: DydxFeatureFlags,
 ) : ViewModel(), DydxViewModel {
     val state: Flow<DydxProfileLaunchIncentivesView.ViewState?> =
         combine(
@@ -52,6 +55,7 @@ class DydxProfileLaunchIncentivesViewModel @Inject constructor(
                     router.navigateTo(url)
                 }
             },
+            isSep2025 = featureFlags.isFeatureEnabled(DydxBoolFeatureFlag.ff_rewards_sep_2025),
         )
     }
 }

--- a/android/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/components/rewards/DydxReceiptRewardsView.kt
+++ b/android/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/components/rewards/DydxReceiptRewardsView.kt
@@ -1,10 +1,19 @@
 package exchange.dydx.trading.feature.receipt.components.rewards
 
+import android.R.attr.path
+import android.R.attr.text
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
@@ -13,9 +22,14 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import exchange.dydx.abacus.protocols.LocalizerProtocol
+import exchange.dydx.abacus.protocols.localizeWithParams
+import exchange.dydx.platformui.components.dashedUnderline
 import exchange.dydx.platformui.components.icons.PlatformRoundImage
+import exchange.dydx.platformui.components.menus.PlatformDropdownMenu
+import exchange.dydx.platformui.components.menus.PlatformMenuItem
 import exchange.dydx.platformui.designSystem.theme.ThemeColor
 import exchange.dydx.platformui.designSystem.theme.ThemeFont
+import exchange.dydx.platformui.designSystem.theme.color
 import exchange.dydx.platformui.designSystem.theme.dydxDefault
 import exchange.dydx.platformui.designSystem.theme.themeColor
 import exchange.dydx.platformui.designSystem.theme.themeFont
@@ -38,6 +52,8 @@ object DydxReceiptRewardsView : DydxComponent {
         val localizer: LocalizerProtocol,
         val nativeTokenLogoUrl: String? = null,
         val rewards: SignedAmountView.ViewState? = null,
+        val rewardsSep2025: SignedAmountView.ViewState? = null,
+        val isSep2025: Boolean = false
     ) {
         companion object {
             val preview = ViewState(
@@ -61,6 +77,70 @@ object DydxReceiptRewardsView : DydxComponent {
             return
         }
 
+        if (state.isSep2025) {
+            RewardsSep2025Content(modifier = modifier, state = state)
+        } else {
+            RewardsContent(modifier = modifier, state = state)
+        }
+    }
+
+    @Composable
+    private fun RewardsSep2025Content(modifier: Modifier, state: ViewState) {
+        val expanded: MutableState<Boolean> = remember {
+            mutableStateOf(false)
+        }
+
+        Row(
+            modifier = modifier,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = state.localizer.localize("APP.GENERAL.MAXIMUM_REWARDS"),
+                    style = TextStyle.dydxDefault
+                        .themeFont(fontSize = ThemeFont.FontSize.small)
+                        .themeColor(ThemeColor.SemanticColor.text_tertiary),
+                    modifier = Modifier
+                        .clickable { expanded.value = !expanded.value }
+                        .dashedUnderline(
+                            color = ThemeColor.SemanticColor.text_tertiary.color,
+                        ),
+                )
+
+                PlatformDropdownMenu(
+                    expanded = expanded,
+                    items = listOf(
+                        PlatformMenuItem(
+                            text = state.localizer.localizeWithParams(
+                                path = "TRADE.MAXIMUM_REWARDS.BODY",
+                                params = mapOf(
+                                    "REWARD_AMOUNT" to "1M",
+                                ),
+                            ),
+                            onClick = { expanded.value = false },
+                        ),
+                    ),
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(0.1f))
+
+            if (state.rewardsSep2025 != null) {
+                SignedAmountView.Content(
+                    modifier = Modifier,
+                    state = state.rewardsSep2025,
+                    textStyle = TextStyle.dydxDefault
+                        .themeFont(fontSize = ThemeFont.FontSize.small, fontType = ThemeFont.FontType.number)
+                        .themeColor(ThemeColor.SemanticColor.text_primary),
+                )
+            } else {
+                DydxReceiptEmptyView()
+            }
+        }
+    }
+
+    @Composable
+    private fun RewardsContent(modifier: Modifier, state: ViewState) {
         Row(
             modifier = modifier,
             verticalAlignment = Alignment.CenterVertically,

--- a/android/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/components/rewards/DydxReceiptRewardsViewModel.kt
+++ b/android/v4/feature/receipt/src/main/java/exchange/dydx/trading/feature/receipt/components/rewards/DydxReceiptRewardsViewModel.kt
@@ -8,6 +8,8 @@ import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.dydxstatemanager.nativeTokenLogoUrl
 import exchange.dydx.platformui.components.PlatformUISign
 import exchange.dydx.trading.common.DydxViewModel
+import exchange.dydx.trading.common.featureflags.DydxBoolFeatureFlag
+import exchange.dydx.trading.common.featureflags.DydxFeatureFlags
 import exchange.dydx.trading.common.formatter.DydxFormatter
 import exchange.dydx.trading.feature.receipt.streams.ReceiptStreaming
 import exchange.dydx.trading.feature.shared.views.SignedAmountView
@@ -15,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import kotlin.math.max
 
 @HiltViewModel
 class DydxReceiptRewardsViewModel @Inject constructor(
@@ -22,6 +25,7 @@ class DydxReceiptRewardsViewModel @Inject constructor(
     private val abacusStateManager: AbacusStateManagerProtocol,
     private val formatter: DydxFormatter,
     val receiptStream: ReceiptStreaming,
+    private val featureFlags: DydxFeatureFlags,
 ) : ViewModel(), DydxViewModel {
 
     val state: Flow<DydxReceiptRewardsView.ViewState?> =
@@ -34,6 +38,8 @@ class DydxReceiptRewardsViewModel @Inject constructor(
     private fun createViewState(tradeSummary: TradeInputSummary?): DydxReceiptRewardsView.ViewState {
         val reward = tradeSummary?.reward ?: 0.0
         val text = formatter.localFormatted(reward, 6)
+        val fee = tradeSummary?.fee ?: 0.0
+        val feeAmount = max(0.0, fee / 2)
         return DydxReceiptRewardsView.ViewState(
             localizer = localizer,
             nativeTokenLogoUrl = abacusStateManager.nativeTokenLogoUrl,
@@ -52,6 +58,16 @@ class DydxReceiptRewardsViewModel @Inject constructor(
             } else {
                 null
             },
+            rewardsSep2025 = if (tradeSummary?.fee != null) {
+                SignedAmountView.ViewState(
+                    text = formatter.dollar(feeAmount, digits = 2),
+                    sign = PlatformUISign.None,
+                    coloringOption = SignedAmountView.ColoringOption.SignOnly,
+                )
+            } else {
+                null
+            },
+            isSep2025 = featureFlags.isFeatureEnabled(DydxBoolFeatureFlag.ff_rewards_sep_2025),
         )
     }
 }

--- a/android/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxAlertsWorker.kt
+++ b/android/v4/feature/workers/src/main/java/exchange/dydx/trading/feature/workers/globalworkers/DydxAlertsWorker.kt
@@ -1,11 +1,14 @@
 package exchange.dydx.trading.feature.workers.globalworkers
 
+import android.system.Os.link
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.dydxstatemanager.AbacusStateManagerProtocol
 import exchange.dydx.platformui.components.container.PlatformInfo
 import exchange.dydx.platformui.components.container.PlatformInfoViewModel
 import exchange.dydx.trading.common.di.CoroutineScopes
+import exchange.dydx.trading.common.featureflags.DydxBoolFeatureFlag
+import exchange.dydx.trading.common.featureflags.DydxFeatureFlags
 import exchange.dydx.trading.common.navigation.DydxRouter
 import exchange.dydx.trading.feature.shared.NotificationEnabled
 import exchange.dydx.utilities.utils.SharedPreferencesStore
@@ -24,6 +27,7 @@ class DydxAlertsWorker @Inject constructor(
     private val router: DydxRouter,
     private val toaster: PlatformInfo,
     private val preferencesStore: SharedPreferencesStore,
+    private val featureFlags: DydxFeatureFlags,
 ) : WorkerProtocol {
     private val handledAlertHashes = mutableSetOf<String>()
 
@@ -58,6 +62,12 @@ class DydxAlertsWorker @Inject constructor(
                 val alertText = alert.text ?: return@forEach
 
                 if (!NotificationEnabled.enabled(preferencesStore)) {
+                    return@forEach
+                }
+
+                if (featureFlags.isFeatureEnabled(DydxBoolFeatureFlag.ff_rewards_sep_2025) &&
+                    alert.id.startsWith("blockReward:")
+                ) {
                     return@forEach
                 }
 

--- a/android/v4/platformUI/src/main/java/exchange/dydx/platformui/components/DashedUnderline.kt
+++ b/android/v4/platformUI/src/main/java/exchange/dydx/platformui/components/DashedUnderline.kt
@@ -1,0 +1,23 @@
+package exchange.dydx.platformui.components
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+
+fun Modifier.dashedUnderline(
+    color: Color = Color.Black,
+    strokeWidth: Float = 2f,
+    dashLength: Float = 10f,
+    gapLength: Float = 10f
+) = this.drawBehind {
+    val y = size.height // baseline for underline
+    drawLine(
+        color = color,
+        start = Offset(0f, y),
+        end = Offset(size.width, y),
+        strokeWidth = strokeWidth,
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(dashLength, gapLength), 0f),
+    )
+}


### PR DESCRIPTION
- Add feature flag
- Disable block reward
- Show receipt line pop-over and use 50% of the estimate fee
- Different text for the trading reward view

| Header | Header |
|--------|--------|
| <img width="1080" height="2400" alt="Screenshot_1756483779" src="https://github.com/user-attachments/assets/86fec074-b5c8-40ae-8b77-a714b7303e6b" /> | <img width="1080" height="2400" alt="Screenshot_1756487224" src="https://github.com/user-attachments/assets/2e56ab13-0ee3-41fb-9baa-3a6f8b1c02b3" />
 | 

